### PR TITLE
[oneseo] Excel 출력 서비스 클래스 성능개선

### DIFF
--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/repository/custom/CustomOneseoRepository.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/repository/custom/CustomOneseoRepository.java
@@ -28,8 +28,6 @@ public interface CustomOneseoRepository {
 
     List<AdmissionTicketsResDto> findAdmissionTickets();
 
-    List<Oneseo> findAllByScreeningDynamic(Screening screening);
-
     Optional<Oneseo> findByGuardianOrTeacherPhoneNumberAndSubmitCode(String phoneNumber, String submitCode);
     Optional<Oneseo> findByGuardianOrTeacherPhoneNumberAndExaminationNumber(String phoneNumber, String examinationNumber);
 

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/repository/custom/CustomOneseoRepository.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/repository/custom/CustomOneseoRepository.java
@@ -32,4 +32,7 @@ public interface CustomOneseoRepository {
     Optional<Oneseo> findByGuardianOrTeacherPhoneNumberAndExaminationNumber(String phoneNumber, String examinationNumber);
 
     Optional<Oneseo> findByMemberNameAndMemberBirthAndPhoneNumber(String memberName, String phoneNumber, LocalDate memberBirth);
+
+    List<Oneseo> findAllByScreeningWithAllDetails(Screening screening);
+    List<Oneseo> findAllFailedWithAllDetails();
 }

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/repository/custom/impl/CustomOneseoRepositoryImpl.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/repository/custom/impl/CustomOneseoRepositoryImpl.java
@@ -61,25 +61,6 @@ public class CustomOneseoRepositoryImpl implements CustomOneseoRepository {
     }
 
     @Override
-    public List<Oneseo> findAllByScreeningDynamic(Screening screening) {
-        boolean isExistAppliedScreening = queryFactory
-                .selectOne()
-                .from(oneseo)
-                .where(oneseo.appliedScreening.isNotNull())
-                .fetchFirst() != null;
-
-        return queryFactory
-                .select(oneseo)
-                .from(oneseo)
-                .join(oneseo.entranceTestResult, entranceTestResult)
-                .where(isExistAppliedScreening
-                        ? oneseo.appliedScreening.eq(screening)
-                        : oneseo.wantedScreening.eq(screening))
-                .orderBy(entranceTestResult.documentEvaluationScore.desc())
-                .fetch();
-    }
-
-    @Override
     public Optional<Oneseo> findByGuardianOrTeacherPhoneNumberAndSubmitCode(String phoneNumber, String submitCode) {
         return Optional.ofNullable(
                 queryFactory.selectFrom(oneseo)

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/DownloadExcelService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/DownloadExcelService.java
@@ -6,31 +6,35 @@ import org.apache.poi.ss.usermodel.Row;
 import org.apache.poi.ss.usermodel.Sheet;
 import org.apache.poi.ss.usermodel.Workbook;
 import org.apache.poi.xssf.streaming.SXSSFWorkbook;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
-import team.themoment.hellogsmv3.domain.oneseo.entity.*;
+import org.springframework.transaction.annotation.Transactional;
+import team.themoment.hellogsmv3.domain.oneseo.entity.EntranceTestResult;
+import team.themoment.hellogsmv3.domain.oneseo.entity.Oneseo;
+import team.themoment.hellogsmv3.domain.oneseo.entity.OneseoPrivacyDetail;
 import team.themoment.hellogsmv3.domain.oneseo.entity.type.Screening;
 import team.themoment.hellogsmv3.domain.oneseo.entity.type.YesNo;
-import team.themoment.hellogsmv3.domain.oneseo.repository.EntranceTestResultRepository;
-import team.themoment.hellogsmv3.domain.oneseo.repository.OneseoPrivacyDetailRepository;
 import team.themoment.hellogsmv3.domain.oneseo.repository.OneseoRepository;
+import team.themoment.hellogsmv3.global.exception.error.ExpectedException;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static team.themoment.hellogsmv3.domain.oneseo.entity.type.Screening.*;
-import static team.themoment.hellogsmv3.domain.oneseo.entity.type.YesNo.NO;
+import static team.themoment.hellogsmv3.domain.oneseo.entity.type.Screening.EXTRA_VETERANS;
 
 @Service
 @RequiredArgsConstructor
 public class DownloadExcelService {
 
     private final OneseoRepository oneseoRepository;
-    private final EntranceTestResultRepository entranceTestResultRepository;
-    private final OneseoPrivacyDetailRepository oneseoPrivacyDetailRepository;
+
+    private static final int BATCH_SIZE = 1000;  // 한 번에 처리할 원서 데이터의 배치 크기
+    private static final int ROW_ACCESS_WINDOW = 100;  // SXSSFWorkbook의 메모리 사용 최적화를 위한 행 접근 윈도우 크기
 
     private static final List<String> HEADER_NAMES = List.of(
             "순번", "접수번호", "성명", "1지망", "2지망", "3지망", "생년월일", "성별", "상세주소", "출신학교",
@@ -38,191 +42,253 @@ public class DownloadExcelService {
             "역량평가점수", "심층면접점수", "최종점수", "최종학과", "지원자연락처", "보호자연락처", "담임연락처", "1차전형결과", "2차전형결과"
     );
 
+    private static final Map<Screening, String> SCREENING_DISPLAY_MAP = Map.of(
+            Screening.GENERAL, "일반전형",
+            Screening.SPECIAL, "특별전형",
+            EXTRA_VETERANS, "국가보훈대상자",
+            Screening.EXTRA_ADMISSION, "특례입학대상자"
+    );
+
+    private static final Map<YesNo, String> PASS_YN_DISPLAY_MAP = Map.of(
+            YesNo.YES, "합격",
+            YesNo.NO, "불합격"
+    );
+
+    @Transactional(readOnly = true)
     public Workbook execute() {
-        Workbook workbook = new SXSSFWorkbook();
-        List<Sheet> sheets = createSheets(workbook);
-        List<List<List<String>>> allSheetData = getAllSheetData();
+        SXSSFWorkbook workbook = new SXSSFWorkbook(ROW_ACCESS_WINDOW);
 
-        for (int i = 0; i < sheets.size(); i++) {
-            Sheet sheet = sheets.get(i);
-            List<List<String>> sheetData = allSheetData.get(i);
-            populateSheet(sheet, sheetData);
+        try {
+            List<Sheet> sheets = createSheets(workbook);
+
+            List<List<String>> generalData = getOneseoDataOptimized(Screening.GENERAL);
+            populateSheet(sheets.get(0), generalData);
+
+            List<List<String>> specialData = getOneseoDataOptimized(Screening.SPECIAL);
+            populateSheet(sheets.get(1), specialData);
+
+            List<List<String>> extraData = getCombinedExtraScreeningDataOptimized();
+            populateSheet(sheets.get(2), extraData);
+
+            List<List<String>> fallenData = getFallenDataOptimized();
+            populateSheet(sheets.get(3), fallenData);
+            return workbook;
+        } catch (Exception e) {
+            try {
+                workbook.close();
+            } catch (Exception closeEx) {
+                throw new ExpectedException("Excel 파일 닫기 중 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR);
+            }
+            throw new ExpectedException("Excel 파일 생성 중 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR);
         }
-
-        return workbook;
     }
 
     private List<Sheet> createSheets(Workbook workbook) {
-        return List.of(
-                workbook.createSheet("일반전형"),
-                workbook.createSheet("특별전형"),
-                workbook.createSheet("정원외 특별전형"),
-                workbook.createSheet("불합격")
-        );
+        List<String> sheetNames = List.of("일반전형", "특별전형", "정원외 특별전형", "불합격");
+        List<Sheet> sheets = new ArrayList<>();
+
+        for (String sheetName : sheetNames) {
+            Sheet sheet = workbook.createSheet(sheetName);
+            createHeaderRow(sheet);
+            sheets.add(sheet);
+        }
+
+        return sheets;
+    }
+
+    private void createHeaderRow(Sheet sheet) {
+        Row headerRow = sheet.createRow(0);
+        for (int i = 0; i < HEADER_NAMES.size(); i++) {
+            Cell cell = headerRow.createCell(i);
+            cell.setCellValue(HEADER_NAMES.get(i));
+        }
     }
 
     private void populateSheet(Sheet sheet, List<List<String>> data) {
-        int rowCount = 0;
-        Row headerRow = sheet.createRow(rowCount++);
-        addDataToRow(headerRow, HEADER_NAMES);
+        int rowIndex = 1;
 
         for (List<String> rowData : data) {
-            Row row = sheet.createRow(rowCount++);
-            addDataToRow(row, rowData);
+            Row row = sheet.createRow(rowIndex++);
+            for (int i = 0; i < rowData.size(); i++) {
+                Cell cell = row.createCell(i);
+                cell.setCellValue(rowData.get(i));
+            }
         }
     }
 
-    private void addDataToRow(Row row, List<String> dataList) {
-        int cellCount = 0;
-        for (String data : dataList) {
-            Cell cell = row.createCell(cellCount++);
-            cell.setCellValue(data);
-        }
+    private List<List<String>> getOneseoDataOptimized(Screening screening) {
+        List<Oneseo> oneseoList = oneseoRepository.findAllByScreeningWithAllDetails(screening);
+        return processOneseoDataOptimized(oneseoList);
     }
 
-    private List<List<List<String>>> getAllSheetData() {
+    private List<List<String>> getCombinedExtraScreeningDataOptimized() {
+        List<Oneseo> extraVeterans = oneseoRepository.findAllByScreeningWithAllDetails(EXTRA_VETERANS);
+        List<Oneseo> extraAdmission = oneseoRepository.findAllByScreeningWithAllDetails(Screening.EXTRA_ADMISSION);
+
+        List<Oneseo> combinedList = Stream.concat(extraVeterans.stream(), extraAdmission.stream())
+                .collect(Collectors.toList());
+
+        return processOneseoDataOptimized(combinedList);
+    }
+
+    private List<List<String>> getFallenDataOptimized() {
+        List<Oneseo> fallenOneseoList = oneseoRepository.findAllFailedWithAllDetails();
+        return processOneseoDataOptimized(fallenOneseoList);
+    }
+
+    private List<List<String>> processOneseoDataOptimized(List<Oneseo> oneseoList) {
+        if (oneseoList.isEmpty()) {
+            return new ArrayList<>();
+        }
+        List<List<String>> result = new ArrayList<>();
+
+        for (int i = 0; i < oneseoList.size(); i += BATCH_SIZE) {
+            int endIndex = Math.min(i + BATCH_SIZE, oneseoList.size());
+            List<Oneseo> batch = oneseoList.subList(i, endIndex);
+
+            List<List<String>> batchResult = processBatch(batch, i + 1);
+            result.addAll(batchResult);
+        }
+
+        return result;
+    }
+
+    private List<List<String>> processBatch(List<Oneseo> batchOneseoList, int startIndex) {
+        List<List<String>> batchResult = new ArrayList<>();
+
+        for (int i = 0; i < batchOneseoList.size(); i++) {
+            Oneseo oneseo = batchOneseoList.get(i);
+            EntranceTestResult entranceTestResult = oneseo.getEntranceTestResult();
+            OneseoPrivacyDetail privacyDetail = oneseo.getOneseoPrivacyDetail();
+
+            List<String> rowData = createRowData(oneseo, entranceTestResult, privacyDetail, startIndex + i);
+            batchResult.add(rowData);
+        }
+
+        return batchResult;
+    }
+
+    private List<String> createRowData(Oneseo oneseo, EntranceTestResult entranceTestResult,
+                                       OneseoPrivacyDetail oneseoPrivacyDetail, int index) {
+
+        BigDecimal finalScore = calculateFinalScore(entranceTestResult);
+
+        String firstDesiredMajor = oneseo.getDesiredMajors() != null ?
+                safeToString(oneseo.getDesiredMajors().getFirstDesiredMajor()) : "";
+        String secondDesiredMajor = oneseo.getDesiredMajors() != null ?
+                safeToString(oneseo.getDesiredMajors().getSecondDesiredMajor()) : "";
+        String thirdDesiredMajor = oneseo.getDesiredMajors() != null ?
+                safeToString(oneseo.getDesiredMajors().getThirdDesiredMajor()) : "";
+
         return List.of(
-                getOneseoData(Screening.GENERAL),
-                getOneseoData(Screening.SPECIAL),
-                getCombinedExtraScreeningData(),
-                getFallenData()
+                String.valueOf(index),
+                formatSubmitCode(oneseo.getOneseoSubmitCode()),
+                safeToString(oneseo.getMember().getName()),
+                firstDesiredMajor,
+                secondDesiredMajor,
+                thirdDesiredMajor,
+                safeToString(oneseo.getMember().getBirth()),
+                convertSex(oneseo.getMember().getSex()),
+                buildAddress(oneseoPrivacyDetail),
+                oneseoPrivacyDetail != null ? safeToString(oneseoPrivacyDetail.getSchoolName()) : "",
+                convertGraduationType(oneseoPrivacyDetail != null ? oneseoPrivacyDetail.getGraduationType() : null),
+                convertScreening(oneseo.getWantedScreening()),
+                convertScreening(oneseo.getAppliedScreening()),
+                getScoreString(entranceTestResult != null && entranceTestResult.getEntranceTestFactorsDetail() != null ?
+                        entranceTestResult.getEntranceTestFactorsDetail().getGeneralSubjectsScore() : null),
+                getScoreString(entranceTestResult != null && entranceTestResult.getEntranceTestFactorsDetail() != null ?
+                        entranceTestResult.getEntranceTestFactorsDetail().getArtsPhysicalSubjectsScore() : null),
+                getScoreString(entranceTestResult != null && entranceTestResult.getEntranceTestFactorsDetail() != null ?
+                        entranceTestResult.getEntranceTestFactorsDetail().getAttendanceScore() : null),
+                getScoreString(entranceTestResult != null && entranceTestResult.getEntranceTestFactorsDetail() != null ?
+                        entranceTestResult.getEntranceTestFactorsDetail().getVolunteerScore() : null),
+                getScoreString(entranceTestResult != null ? entranceTestResult.getDocumentEvaluationScore() : null),
+                getScoreString(entranceTestResult != null ? entranceTestResult.getCompetencyEvaluationScore() : null),
+                getScoreString(entranceTestResult != null ? entranceTestResult.getInterviewScore() : null),
+                getScoreString(finalScore),
+                safeToString(oneseo.getDecidedMajor()),
+                safeToString(oneseo.getMember().getPhoneNumber()),
+                oneseoPrivacyDetail != null ? safeToString(oneseoPrivacyDetail.getGuardianPhoneNumber()) : "",
+                oneseoPrivacyDetail != null ? safeToString(oneseoPrivacyDetail.getSchoolTeacherPhoneNumber()) : "",
+                convertTestPassYn(entranceTestResult != null ? entranceTestResult.getFirstTestPassYn() : null),
+                convertTestPassYn(entranceTestResult != null ? entranceTestResult.getSecondTestPassYn() : null)
         );
     }
 
-    private List<List<String>> getOneseoData(Screening screening) {
-        List<Oneseo> oneseoList = oneseoRepository.findAllByScreeningDynamic(screening);
-        return oneseoToExcelDataList(oneseoList);
-    }
-
-    private List<List<String>> getCombinedExtraScreeningData() {
-        List<Oneseo> extraOneseoList = Stream.concat(
-                oneseoRepository.findAllByScreeningDynamic(EXTRA_VETERANS).stream(),
-                oneseoRepository.findAllByScreeningDynamic(Screening.EXTRA_ADMISSION).stream()
-        ).collect(Collectors.toList());
-
-        return oneseoToExcelDataList(extraOneseoList);
-    }
-
-    private List<List<String>> getFallenData() {
-        List<Oneseo> fallenOneseo = entranceTestResultRepository
-                .findAllByFirstTestPassYnOrSecondTestPassYn(NO, NO).stream()
-                .map(EntranceTestResult::getOneseo)
-                .collect(Collectors.toList());
-
-        return oneseoToExcelDataList(fallenOneseo);
-    }
-
-    private List<List<String>> oneseoToExcelDataList(List<Oneseo> oneseoList) {
-        List<List<String>> sheetData = new ArrayList<>();
-        int index = 1;
-
-        for (Oneseo oneseo : oneseoList) {
-            EntranceTestResult entranceTestResult = entranceTestResultRepository.findByOneseo(oneseo);
-
-            OneseoPrivacyDetail oneseoPrivacyDetail = oneseoPrivacyDetailRepository.findByOneseo(oneseo);
-
-            BigDecimal finalScore = calculateFinalScore(entranceTestResult);
-
-            String sex = null;
-            String graduationType = null;
-
-            switch (oneseo.getMember().getSex()) {
-                case MALE -> sex = "남자";
-                case FEMALE -> sex = "여자";
-            }
-
-            switch (oneseoPrivacyDetail.getGraduationType()) {
-                case CANDIDATE -> graduationType = "졸업예정자";
-                case GRADUATE -> graduationType = "졸업자";
-                case GED -> graduationType = "검정고시";
-            }
-
-            String wantedScreening = convertScreening(oneseo.getWantedScreening());
-            String appliedScreening = convertScreening(oneseo.getAppliedScreening());
-
-            String submitCode = oneseo.getOneseoSubmitCode();
-
-            List<String> rowData = List.of(
-                    String.valueOf(index++),
-                    formatSubmitCode(submitCode),
-                    String.valueOf(oneseo.getMember().getName()),
-                    String.valueOf(oneseo.getDesiredMajors().getFirstDesiredMajor()),
-                    String.valueOf(oneseo.getDesiredMajors().getSecondDesiredMajor()),
-                    String.valueOf(oneseo.getDesiredMajors().getThirdDesiredMajor()),
-                    String.valueOf(oneseo.getMember().getBirth()),
-                    String.valueOf(sex),
-                    (oneseoPrivacyDetail.getAddress() + oneseoPrivacyDetail.getDetailAddress()),
-                    String.valueOf(oneseoPrivacyDetail.getSchoolName()),
-                    String.valueOf(graduationType),
-                    String.valueOf(wantedScreening),
-                    String.valueOf(appliedScreening),
-                    String.valueOf(entranceTestResult.getEntranceTestFactorsDetail().getGeneralSubjectsScore()),
-                    String.valueOf(entranceTestResult.getEntranceTestFactorsDetail().getArtsPhysicalSubjectsScore()),
-                    String.valueOf(entranceTestResult.getEntranceTestFactorsDetail().getAttendanceScore()),
-                    String.valueOf(entranceTestResult.getEntranceTestFactorsDetail().getVolunteerScore()),
-                    String.valueOf(entranceTestResult.getDocumentEvaluationScore()),
-                    String.valueOf(entranceTestResult.getCompetencyEvaluationScore()),
-                    String.valueOf(entranceTestResult.getInterviewScore()),
-                    String.valueOf(finalScore),
-                    String.valueOf(oneseo.getDecidedMajor()),
-                    String.valueOf(oneseo.getMember().getPhoneNumber()),
-                    String.valueOf(oneseoPrivacyDetail.getGuardianPhoneNumber()),
-                    String.valueOf(oneseoPrivacyDetail.getSchoolTeacherPhoneNumber()),
-                    String.valueOf(convertTestPassYn(entranceTestResult.getFirstTestPassYn())),
-                    String.valueOf(convertTestPassYn(entranceTestResult.getSecondTestPassYn()))
-            );
-
-            sheetData.add(rowData.stream().map(data -> data.equals("null") ? "" : data).collect(Collectors.toList()));
-        }
-
-        return sheetData;
+    private String safeToString(Object obj) {
+        return obj != null ? obj.toString() : "";
     }
 
     private String formatSubmitCode(String submitCode) {
-        // submitCode format: A-001
+        if (submitCode == null) return "";
         String[] parts = submitCode.split("-");
-        String prefix = parts[0];
-        String number = String.format("%03d", Integer.parseInt(parts[1]));
-        return prefix + "-" + number;
+        if (parts.length != 2) return submitCode;
+
+        try {
+            String prefix = parts[0];
+            String number = String.format("%03d", Integer.parseInt(parts[1]));
+            return prefix + "-" + number;
+        } catch (NumberFormatException e) {
+            return submitCode;
+        }
+    }
+
+    private String convertSex(team.themoment.hellogsmv3.domain.member.entity.type.Sex sex) {
+        if (sex == null) return "";
+        return switch (sex) {
+            case MALE -> "남자";
+            case FEMALE -> "여자";
+        };
+    }
+
+    private String buildAddress(OneseoPrivacyDetail privacyDetail) {
+        if (privacyDetail == null) return "";
+        String address = privacyDetail.getAddress();
+        String detailAddress = privacyDetail.getDetailAddress();
+        return (address != null ? address : "") + (detailAddress != null ? " " + detailAddress : "");
+    }
+
+    private String convertGraduationType(team.themoment.hellogsmv3.domain.oneseo.entity.type.GraduationType graduationType) {
+        if (graduationType == null) return "";
+        return switch (graduationType) {
+            case CANDIDATE -> "졸업예정자";
+            case GRADUATE -> "졸업자";
+            case GED -> "검정고시";
+        };
     }
 
     private String convertScreening(Screening screening) {
-        if (screening == null) return null;
-
-        return switch (screening) {
-            case GENERAL -> "일반전형";
-            case SPECIAL -> "특별전형";
-            case EXTRA_VETERANS -> "국가보훈대상자";
-            case EXTRA_ADMISSION -> "특례입학대상자";
-        };
+        if (screening == null) return "";
+        return SCREENING_DISPLAY_MAP.getOrDefault(screening, "");
     }
 
     private String convertTestPassYn(YesNo yn) {
-        if (yn == null) return null;
+        if (yn == null) return "";
+        return PASS_YN_DISPLAY_MAP.getOrDefault(yn, "");
+    }
 
-        return switch (yn) {
-            case YES -> "합격";
-            case NO -> "불합격";
-        };
+    private String getScoreString(BigDecimal score) {
+        return score != null ? score.toString() : "";
     }
 
     private BigDecimal calculateFinalScore(EntranceTestResult entranceTestResult) {
+        if (entranceTestResult == null) return null;
 
         BigDecimal competencyEvaluationScore = entranceTestResult.getCompetencyEvaluationScore();
         BigDecimal interviewScore = entranceTestResult.getInterviewScore();
+        BigDecimal documentEvaluationScore = entranceTestResult.getDocumentEvaluationScore();
 
-        if (
-                entranceTestResult.getSecondTestPassYn() == null
-                        || competencyEvaluationScore == null
-                        || interviewScore == null
-        ) {
+        if (entranceTestResult.getSecondTestPassYn() == null
+                || competencyEvaluationScore == null
+                || interviewScore == null
+                || documentEvaluationScore == null) {
             return null;
         }
 
-        BigDecimal documentEvaluationScore = entranceTestResult.getDocumentEvaluationScore()
+        BigDecimal adjustedDocumentScore = documentEvaluationScore
                 .divide(BigDecimal.valueOf(3), 3, RoundingMode.HALF_UP);
 
-        return documentEvaluationScore.multiply(BigDecimal.valueOf(0.5))
+        return adjustedDocumentScore.multiply(BigDecimal.valueOf(0.5))
                 .add(competencyEvaluationScore.multiply(BigDecimal.valueOf(0.3)))
                 .add(interviewScore.multiply(BigDecimal.valueOf(0.2)))
                 .setScale(3, RoundingMode.HALF_UP);

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/DownloadExcelService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/DownloadExcelService.java
@@ -173,12 +173,9 @@ public class DownloadExcelService {
 
         BigDecimal finalScore = calculateFinalScore(entranceTestResult);
 
-        String firstDesiredMajor = oneseo.getDesiredMajors() != null ?
-                safeToString(oneseo.getDesiredMajors().getFirstDesiredMajor()) : "";
-        String secondDesiredMajor = oneseo.getDesiredMajors() != null ?
-                safeToString(oneseo.getDesiredMajors().getSecondDesiredMajor()) : "";
-        String thirdDesiredMajor = oneseo.getDesiredMajors() != null ?
-                safeToString(oneseo.getDesiredMajors().getThirdDesiredMajor()) : "";
+        String firstDesiredMajor = safeToString(oneseo.getDesiredMajors().getFirstDesiredMajor());
+        String secondDesiredMajor = safeToString(oneseo.getDesiredMajors().getSecondDesiredMajor());
+        String thirdDesiredMajor = safeToString(oneseo.getDesiredMajors().getThirdDesiredMajor());
 
         return List.of(
                 String.valueOf(index),
@@ -190,28 +187,24 @@ public class DownloadExcelService {
                 safeToString(oneseo.getMember().getBirth()),
                 convertSex(oneseo.getMember().getSex()),
                 buildAddress(oneseoPrivacyDetail),
-                oneseoPrivacyDetail != null ? safeToString(oneseoPrivacyDetail.getSchoolName()) : "",
-                convertGraduationType(oneseoPrivacyDetail != null ? oneseoPrivacyDetail.getGraduationType() : null),
+                safeToString(oneseoPrivacyDetail.getSchoolName()),
+                convertGraduationType(oneseoPrivacyDetail.getGraduationType()),
                 convertScreening(oneseo.getWantedScreening()),
                 convertScreening(oneseo.getAppliedScreening()),
-                getScoreString(entranceTestResult != null && entranceTestResult.getEntranceTestFactorsDetail() != null ?
-                        entranceTestResult.getEntranceTestFactorsDetail().getGeneralSubjectsScore() : null),
-                getScoreString(entranceTestResult != null && entranceTestResult.getEntranceTestFactorsDetail() != null ?
-                        entranceTestResult.getEntranceTestFactorsDetail().getArtsPhysicalSubjectsScore() : null),
-                getScoreString(entranceTestResult != null && entranceTestResult.getEntranceTestFactorsDetail() != null ?
-                        entranceTestResult.getEntranceTestFactorsDetail().getAttendanceScore() : null),
-                getScoreString(entranceTestResult != null && entranceTestResult.getEntranceTestFactorsDetail() != null ?
-                        entranceTestResult.getEntranceTestFactorsDetail().getVolunteerScore() : null),
-                getScoreString(entranceTestResult != null ? entranceTestResult.getDocumentEvaluationScore() : null),
-                getScoreString(entranceTestResult != null ? entranceTestResult.getCompetencyEvaluationScore() : null),
-                getScoreString(entranceTestResult != null ? entranceTestResult.getInterviewScore() : null),
+                getScoreString(entranceTestResult.getEntranceTestFactorsDetail().getGeneralSubjectsScore()),
+                getScoreString(entranceTestResult.getEntranceTestFactorsDetail().getArtsPhysicalSubjectsScore()),
+                getScoreString(entranceTestResult.getEntranceTestFactorsDetail().getAttendanceScore()),
+                getScoreString(entranceTestResult.getEntranceTestFactorsDetail().getVolunteerScore()),
+                getScoreString(entranceTestResult.getDocumentEvaluationScore()),
+                getScoreString(entranceTestResult.getCompetencyEvaluationScore()),
+                getScoreString(entranceTestResult.getInterviewScore()),
                 getScoreString(finalScore),
                 safeToString(oneseo.getDecidedMajor()),
                 safeToString(oneseo.getMember().getPhoneNumber()),
-                oneseoPrivacyDetail != null ? safeToString(oneseoPrivacyDetail.getGuardianPhoneNumber()) : "",
-                oneseoPrivacyDetail != null ? safeToString(oneseoPrivacyDetail.getSchoolTeacherPhoneNumber()) : "",
-                convertTestPassYn(entranceTestResult != null ? entranceTestResult.getFirstTestPassYn() : null),
-                convertTestPassYn(entranceTestResult != null ? entranceTestResult.getSecondTestPassYn() : null)
+                safeToString(oneseoPrivacyDetail.getGuardianPhoneNumber()),
+                safeToString(oneseoPrivacyDetail.getSchoolTeacherPhoneNumber()),
+                convertTestPassYn(entranceTestResult.getFirstTestPassYn()),
+                convertTestPassYn(entranceTestResult.getSecondTestPassYn())
         );
     }
 


### PR DESCRIPTION
## 개요
기존 지나치게 많은 자원과 시간을 소비하던 Excel를 생성하여 반환하는 API를 개선하여 리소스 사용량과 응답시간을 대폭 개선하였습니다,
리팩터링과 함께 테스트 코드 역시 수정하였습니다

## 본문

- **기존**: 각 Oneseo마다 EntranceTestResult와 OneseoPrivacyDetail을 개별 조회(N+1 문제 발생),사용자 정보가 많다면 무제한으로 메모리를 점유함
- **개선**: fetch join을 사용하여 모든 연관 엔티티를 한 번에 조회,100건 단위로 배치처리를 하도록 설정하였으며 이를 통하여 순간적인 과도한 리소스 사용 문제 해결

테스트 케이스 역시 변동되었습니다
```
DownloadExcelService 클래스의
├── execute 메소드는
│   ├── 정상적인 데이터가 있을 때
│   │   └── 모든 전형의 시트를 생성하고 데이터를 채운다
│   │
│   └── 빈 데이터가 있을 때
│       └── 헤더만 있는 시트를 생성한다
│
└── 점수 계산 로직은
    ├── 유효한 점수가 있을 때
    │   └── 최종 점수를 올바르게 계산한다
    │
    └── null 점수가 있을 때
        └── 빈 문자열을 반환한다
```
### 변경

기존에 ``OneseoRepository``에서 ``findAllByScreeningDynamic``메서드가 존재하였는데 이 리팩터링으로 사용처가 사라져 제거하였습니다

### 기타

로컬환경 기준 최소 응답시간이 13.13초에서 1.03초로 단축되어 **92.08%** 이상 단축(Postman에서 5회 요청하여 평균을 낸 값)
단순 Postman을 이용하여 10회 요청 시 평균 3~4초에서 312ms로 단축되어 **90%** 이상 단축