### PR TITLE
[oneseo] 파일스트림 처리를 포함한 두꺼운 트랙잭션 블록제거

### DIFF
--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/UploadExcelService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/UploadExcelService.java
@@ -5,7 +5,6 @@ import lombok.RequiredArgsConstructor;
 import org.apache.poi.ss.usermodel.*;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 import team.themoment.hellogsmv3.domain.oneseo.dto.internal.SecondTestResultDto;
 import team.themoment.hellogsmv3.domain.oneseo.entity.EntranceTestResult;
@@ -40,7 +39,6 @@ public class UploadExcelService {
         }
     }
 
-    @Transactional
     public void execute(MultipartFile file) {
         Workbook workbook = createWorkbookFromFile(file);
         Sheet sheet = workbook.getSheetAt(0);


### PR DESCRIPTION
## 개요

엑셀파일 처리를 포함한 두꺼운 트랙잭션 블록제거

## 본문

이전코드는 엑셀파일 처리를 포함한 서비스 메서드에 @Transactional 어노테이션이 있어, 불필요하게 오랬동안 DB 커넥션을 유지하던 문제가 있었습니다.

[디스코드에서 받은 피드백](https://discord.com/channels/942787694872899604/991121778158080090/1402471606823161936)에 따라서, @Transactional  어노테이션을 삭제했습니다.