### PR TITLE
[global] 레포지터리 패키지 명칭 통일

### DIFF
--- a/src/main/java/team/themoment/hellogsmv3/domain/common/operation/repository/OperationTestResultRepository.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/common/operation/repository/OperationTestResultRepository.java
@@ -1,4 +1,4 @@
-package team.themoment.hellogsmv3.domain.common.operation.repo;
+package team.themoment.hellogsmv3.domain.common.operation.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;

--- a/src/main/java/team/themoment/hellogsmv3/domain/common/operation/service/AnnounceFirstTestResultService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/common/operation/service/AnnounceFirstTestResultService.java
@@ -5,7 +5,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import team.themoment.hellogsmv3.domain.common.operation.entity.OperationTestResult;
-import team.themoment.hellogsmv3.domain.common.operation.repo.OperationTestResultRepository;
+import team.themoment.hellogsmv3.domain.common.operation.repository.OperationTestResultRepository;
 import team.themoment.hellogsmv3.domain.oneseo.repository.EntranceTestResultRepository;
 import team.themoment.hellogsmv3.global.exception.error.ExpectedException;
 import team.themoment.hellogsmv3.global.security.data.ScheduleEnvironment;

--- a/src/main/java/team/themoment/hellogsmv3/domain/common/operation/service/AnnounceSecondTestResultService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/common/operation/service/AnnounceSecondTestResultService.java
@@ -5,7 +5,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import team.themoment.hellogsmv3.domain.common.operation.entity.OperationTestResult;
-import team.themoment.hellogsmv3.domain.common.operation.repo.OperationTestResultRepository;
+import team.themoment.hellogsmv3.domain.common.operation.repository.OperationTestResultRepository;
 import team.themoment.hellogsmv3.domain.oneseo.repository.EntranceTestResultRepository;
 import team.themoment.hellogsmv3.global.exception.error.ExpectedException;
 import team.themoment.hellogsmv3.global.security.data.ScheduleEnvironment;

--- a/src/main/java/team/themoment/hellogsmv3/domain/common/operation/service/QueryAnnounceTestResultService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/common/operation/service/QueryAnnounceTestResultService.java
@@ -6,7 +6,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import team.themoment.hellogsmv3.domain.common.operation.dto.response.AnnounceTestResultResDto;
 import team.themoment.hellogsmv3.domain.common.operation.entity.OperationTestResult;
-import team.themoment.hellogsmv3.domain.common.operation.repo.OperationTestResultRepository;
+import team.themoment.hellogsmv3.domain.common.operation.repository.OperationTestResultRepository;
 import team.themoment.hellogsmv3.global.exception.error.ExpectedException;
 
 @Service

--- a/src/main/java/team/themoment/hellogsmv3/domain/common/testResult/service/impl/GenerateTestResultCodeServiceImpl.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/common/testResult/service/impl/GenerateTestResultCodeServiceImpl.java
@@ -5,7 +5,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import team.themoment.hellogsmv3.domain.member.dto.request.GenerateCodeReqDto;
 import team.themoment.hellogsmv3.domain.member.entity.AuthenticationCode;
-import team.themoment.hellogsmv3.domain.member.repo.CodeRepository;
+import team.themoment.hellogsmv3.domain.member.repository.CodeRepository;
 import team.themoment.hellogsmv3.domain.member.service.GenerateCodeService;
 import team.themoment.hellogsmv3.domain.member.service.SendCodeNotificationService;
 import team.themoment.hellogsmv3.global.exception.error.ExpectedException;

--- a/src/main/java/team/themoment/hellogsmv3/domain/member/repository/CodeRepository.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/member/repository/CodeRepository.java
@@ -1,4 +1,4 @@
-package team.themoment.hellogsmv3.domain.member.repo;
+package team.themoment.hellogsmv3.domain.member.repository;
 
 import org.springframework.data.repository.CrudRepository;
 import team.themoment.hellogsmv3.domain.member.entity.AuthenticationCode;

--- a/src/main/java/team/themoment/hellogsmv3/domain/member/repository/MemberRepository.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/member/repository/MemberRepository.java
@@ -1,4 +1,4 @@
-package team.themoment.hellogsmv3.domain.member.repo;
+package team.themoment.hellogsmv3.domain.member.repository;
 
 import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;

--- a/src/main/java/team/themoment/hellogsmv3/domain/member/service/AuthenticateCodeService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/member/service/AuthenticateCodeService.java
@@ -7,7 +7,7 @@ import org.springframework.transaction.annotation.Transactional;
 import team.themoment.hellogsmv3.domain.member.dto.request.AuthenticateCodeReqDto;
 import team.themoment.hellogsmv3.domain.member.entity.AuthenticationCode;
 import team.themoment.hellogsmv3.domain.member.entity.type.AuthCodeType;
-import team.themoment.hellogsmv3.domain.member.repo.CodeRepository;
+import team.themoment.hellogsmv3.domain.member.repository.CodeRepository;
 import team.themoment.hellogsmv3.global.exception.error.ExpectedException;
 
 @Service

--- a/src/main/java/team/themoment/hellogsmv3/domain/member/service/CommonCodeService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/member/service/CommonCodeService.java
@@ -5,7 +5,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import team.themoment.hellogsmv3.domain.member.entity.AuthenticationCode;
 import team.themoment.hellogsmv3.domain.member.entity.type.AuthCodeType;
-import team.themoment.hellogsmv3.domain.member.repo.CodeRepository;
+import team.themoment.hellogsmv3.domain.member.repository.CodeRepository;
 import team.themoment.hellogsmv3.global.exception.error.ExpectedException;
 
 @Service

--- a/src/main/java/team/themoment/hellogsmv3/domain/member/service/CreateMemberService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/member/service/CreateMemberService.java
@@ -8,7 +8,7 @@ import org.springframework.transaction.annotation.Transactional;
 import team.themoment.hellogsmv3.domain.member.dto.request.CreateMemberReqDto;
 import team.themoment.hellogsmv3.domain.member.entity.Member;
 import team.themoment.hellogsmv3.domain.member.entity.type.Role;
-import team.themoment.hellogsmv3.domain.member.repo.MemberRepository;
+import team.themoment.hellogsmv3.domain.member.repository.MemberRepository;
 import team.themoment.hellogsmv3.domain.oneseo.repository.*;
 import team.themoment.hellogsmv3.global.exception.error.ExpectedException;
 import team.themoment.hellogsmv3.global.security.data.ScheduleEnvironment;

--- a/src/main/java/team/themoment/hellogsmv3/domain/member/service/GenerateCodeService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/member/service/GenerateCodeService.java
@@ -3,7 +3,7 @@ package team.themoment.hellogsmv3.domain.member.service;
 import team.themoment.hellogsmv3.domain.member.dto.request.GenerateCodeReqDto;
 import team.themoment.hellogsmv3.domain.member.entity.AuthenticationCode;
 import team.themoment.hellogsmv3.domain.member.entity.type.AuthCodeType;
-import team.themoment.hellogsmv3.domain.member.repo.CodeRepository;
+import team.themoment.hellogsmv3.domain.member.repository.CodeRepository;
 
 import java.time.LocalDateTime;
 import java.util.Random;

--- a/src/main/java/team/themoment/hellogsmv3/domain/member/service/MemberService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/member/service/MemberService.java
@@ -4,7 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import team.themoment.hellogsmv3.domain.member.entity.Member;
-import team.themoment.hellogsmv3.domain.member.repo.MemberRepository;
+import team.themoment.hellogsmv3.domain.member.repository.MemberRepository;
 import team.themoment.hellogsmv3.global.exception.error.ExpectedException;
 
 @Service

--- a/src/main/java/team/themoment/hellogsmv3/domain/member/service/QueryCheckDuplicateMemberService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/member/service/QueryCheckDuplicateMemberService.java
@@ -3,7 +3,7 @@ package team.themoment.hellogsmv3.domain.member.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import team.themoment.hellogsmv3.domain.member.dto.response.FoundDuplicateMemberResDto;
-import team.themoment.hellogsmv3.domain.member.repo.MemberRepository;
+import team.themoment.hellogsmv3.domain.member.repository.MemberRepository;
 
 import static team.themoment.hellogsmv3.domain.oneseo.entity.type.YesNo.*;
 

--- a/src/main/java/team/themoment/hellogsmv3/domain/member/service/QueryMemberAuthInfoByIdService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/member/service/QueryMemberAuthInfoByIdService.java
@@ -5,7 +5,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import team.themoment.hellogsmv3.domain.member.dto.response.FoundMemberAuthInfoResDto;
 import team.themoment.hellogsmv3.domain.member.entity.Member;
-import team.themoment.hellogsmv3.domain.member.repo.MemberRepository;
+import team.themoment.hellogsmv3.domain.member.repository.MemberRepository;
 import team.themoment.hellogsmv3.global.exception.error.ExpectedException;
 
 @Service

--- a/src/main/java/team/themoment/hellogsmv3/domain/member/service/QueryMemberByIdService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/member/service/QueryMemberByIdService.java
@@ -6,7 +6,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import team.themoment.hellogsmv3.domain.member.dto.response.FoundMemberResDto;
 import team.themoment.hellogsmv3.domain.member.entity.Member;
-import team.themoment.hellogsmv3.domain.member.repo.MemberRepository;
+import team.themoment.hellogsmv3.domain.member.repository.MemberRepository;
 import team.themoment.hellogsmv3.global.exception.error.ExpectedException;
 
 @Service

--- a/src/main/java/team/themoment/hellogsmv3/domain/member/service/impl/GenerateCodeServiceImpl.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/member/service/impl/GenerateCodeServiceImpl.java
@@ -5,7 +5,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import team.themoment.hellogsmv3.domain.member.dto.request.GenerateCodeReqDto;
 import team.themoment.hellogsmv3.domain.member.entity.AuthenticationCode;
-import team.themoment.hellogsmv3.domain.member.repo.CodeRepository;
+import team.themoment.hellogsmv3.domain.member.repository.CodeRepository;
 import team.themoment.hellogsmv3.domain.member.service.GenerateCodeService;
 import team.themoment.hellogsmv3.domain.member.service.SendCodeNotificationService;
 import team.themoment.hellogsmv3.global.exception.error.ExpectedException;

--- a/src/main/java/team/themoment/hellogsmv3/domain/member/service/impl/GenerateTestCodeServiceImpl.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/member/service/impl/GenerateTestCodeServiceImpl.java
@@ -4,7 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import team.themoment.hellogsmv3.domain.member.dto.request.GenerateCodeReqDto;
 import team.themoment.hellogsmv3.domain.member.entity.AuthenticationCode;
-import team.themoment.hellogsmv3.domain.member.repo.CodeRepository;
+import team.themoment.hellogsmv3.domain.member.repository.CodeRepository;
 import team.themoment.hellogsmv3.domain.member.service.GenerateCodeService;
 
 import java.util.Random;

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/OneseoService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/OneseoService.java
@@ -3,7 +3,7 @@ package team.themoment.hellogsmv3.domain.oneseo.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
-import team.themoment.hellogsmv3.domain.common.operation.repo.OperationTestResultRepository;
+import team.themoment.hellogsmv3.domain.common.operation.repository.OperationTestResultRepository;
 import team.themoment.hellogsmv3.domain.member.entity.Member;
 import team.themoment.hellogsmv3.domain.oneseo.dto.internal.MiddleSchoolAchievementCalcDto;
 import team.themoment.hellogsmv3.domain.oneseo.dto.request.MiddleSchoolAchievementReqDto;

--- a/src/main/java/team/themoment/hellogsmv3/global/security/auth/service/OAuthAuthenticationService.java
+++ b/src/main/java/team/themoment/hellogsmv3/global/security/auth/service/OAuthAuthenticationService.java
@@ -16,7 +16,7 @@ import org.springframework.stereotype.Service;
 import team.themoment.hellogsmv3.domain.member.entity.Member;
 import team.themoment.hellogsmv3.domain.member.entity.type.AuthReferrerType;
 import team.themoment.hellogsmv3.domain.member.entity.type.Role;
-import team.themoment.hellogsmv3.domain.member.repo.MemberRepository;
+import team.themoment.hellogsmv3.domain.member.repository.MemberRepository;
 import team.themoment.hellogsmv3.global.security.auth.dto.UserAuthInfo;
 import team.themoment.hellogsmv3.global.security.auth.service.provider.OAuthProvider;
 

--- a/src/test/java/team/themoment/hellogsmv3/domain/common/service/AnnounceFirstTestResultServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/common/service/AnnounceFirstTestResultServiceTest.java
@@ -9,7 +9,7 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.springframework.http.HttpStatus;
 import team.themoment.hellogsmv3.domain.common.operation.entity.OperationTestResult;
-import team.themoment.hellogsmv3.domain.common.operation.repo.OperationTestResultRepository;
+import team.themoment.hellogsmv3.domain.common.operation.repository.OperationTestResultRepository;
 import team.themoment.hellogsmv3.domain.common.operation.service.AnnounceFirstTestResultService;
 import team.themoment.hellogsmv3.domain.oneseo.repository.EntranceTestResultRepository;
 import team.themoment.hellogsmv3.global.exception.error.ExpectedException;

--- a/src/test/java/team/themoment/hellogsmv3/domain/common/service/AnnounceSecondTestResultServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/common/service/AnnounceSecondTestResultServiceTest.java
@@ -9,7 +9,7 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.springframework.http.HttpStatus;
 import team.themoment.hellogsmv3.domain.common.operation.entity.OperationTestResult;
-import team.themoment.hellogsmv3.domain.common.operation.repo.OperationTestResultRepository;
+import team.themoment.hellogsmv3.domain.common.operation.repository.OperationTestResultRepository;
 import team.themoment.hellogsmv3.domain.common.operation.service.AnnounceSecondTestResultService;
 import team.themoment.hellogsmv3.domain.oneseo.repository.EntranceTestResultRepository;
 import team.themoment.hellogsmv3.global.exception.error.ExpectedException;

--- a/src/test/java/team/themoment/hellogsmv3/domain/common/service/QueryAnnounceTestResultServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/common/service/QueryAnnounceTestResultServiceTest.java
@@ -10,7 +10,7 @@ import org.mockito.MockitoAnnotations;
 import org.springframework.http.HttpStatus;
 import team.themoment.hellogsmv3.domain.common.operation.dto.response.AnnounceTestResultResDto;
 import team.themoment.hellogsmv3.domain.common.operation.entity.OperationTestResult;
-import team.themoment.hellogsmv3.domain.common.operation.repo.OperationTestResultRepository;
+import team.themoment.hellogsmv3.domain.common.operation.repository.OperationTestResultRepository;
 import team.themoment.hellogsmv3.domain.common.operation.service.QueryAnnounceTestResultService;
 import team.themoment.hellogsmv3.global.exception.error.ExpectedException;
 

--- a/src/test/java/team/themoment/hellogsmv3/domain/member/service/AuthenticateCodeServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/member/service/AuthenticateCodeServiceTest.java
@@ -11,8 +11,7 @@ import org.mockito.MockitoAnnotations;
 import org.springframework.http.HttpStatus;
 import team.themoment.hellogsmv3.domain.member.dto.request.AuthenticateCodeReqDto;
 import team.themoment.hellogsmv3.domain.member.entity.AuthenticationCode;
-import team.themoment.hellogsmv3.domain.member.entity.type.AuthCodeType;
-import team.themoment.hellogsmv3.domain.member.repo.CodeRepository;
+import team.themoment.hellogsmv3.domain.member.repository.CodeRepository;
 import team.themoment.hellogsmv3.global.exception.error.ExpectedException;
 
 import java.time.LocalDateTime;

--- a/src/test/java/team/themoment/hellogsmv3/domain/member/service/CommonCodeServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/member/service/CommonCodeServiceTest.java
@@ -9,7 +9,7 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.springframework.http.HttpStatus;
 import team.themoment.hellogsmv3.domain.member.entity.AuthenticationCode;
-import team.themoment.hellogsmv3.domain.member.repo.CodeRepository;
+import team.themoment.hellogsmv3.domain.member.repository.CodeRepository;
 import team.themoment.hellogsmv3.global.exception.error.ExpectedException;
 
 import java.time.LocalDateTime;

--- a/src/test/java/team/themoment/hellogsmv3/domain/member/service/CreateMemberServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/member/service/CreateMemberServiceTest.java
@@ -13,7 +13,7 @@ import team.themoment.hellogsmv3.domain.member.entity.Member;
 import team.themoment.hellogsmv3.domain.member.entity.type.AuthReferrerType;
 import team.themoment.hellogsmv3.domain.member.entity.type.Role;
 import team.themoment.hellogsmv3.domain.member.entity.type.Sex;
-import team.themoment.hellogsmv3.domain.member.repo.MemberRepository;
+import team.themoment.hellogsmv3.domain.member.repository.MemberRepository;
 import team.themoment.hellogsmv3.domain.oneseo.repository.EntranceTestResultRepository;
 import team.themoment.hellogsmv3.domain.oneseo.repository.OneseoRepository;
 import team.themoment.hellogsmv3.global.exception.error.ExpectedException;

--- a/src/test/java/team/themoment/hellogsmv3/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/member/service/MemberServiceTest.java
@@ -9,7 +9,7 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.springframework.http.HttpStatus;
 import team.themoment.hellogsmv3.domain.member.entity.Member;
-import team.themoment.hellogsmv3.domain.member.repo.MemberRepository;
+import team.themoment.hellogsmv3.domain.member.repository.MemberRepository;
 import team.themoment.hellogsmv3.global.exception.error.ExpectedException;
 
 import java.util.Optional;

--- a/src/test/java/team/themoment/hellogsmv3/domain/member/service/QueryCheckDuplicateMemberServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/member/service/QueryCheckDuplicateMemberServiceTest.java
@@ -8,7 +8,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import team.themoment.hellogsmv3.domain.member.dto.response.FoundDuplicateMemberResDto;
-import team.themoment.hellogsmv3.domain.member.repo.MemberRepository;
+import team.themoment.hellogsmv3.domain.member.repository.MemberRepository;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.BDDMockito.given;

--- a/src/test/java/team/themoment/hellogsmv3/domain/member/service/QueryMemberAuthInfoByIdServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/member/service/QueryMemberAuthInfoByIdServiceTest.java
@@ -12,7 +12,7 @@ import team.themoment.hellogsmv3.domain.member.dto.response.FoundMemberAuthInfoR
 import team.themoment.hellogsmv3.domain.member.entity.Member;
 import team.themoment.hellogsmv3.domain.member.entity.type.AuthReferrerType;
 import team.themoment.hellogsmv3.domain.member.entity.type.Role;
-import team.themoment.hellogsmv3.domain.member.repo.MemberRepository;
+import team.themoment.hellogsmv3.domain.member.repository.MemberRepository;
 import team.themoment.hellogsmv3.global.exception.error.ExpectedException;
 
 import java.util.Optional;

--- a/src/test/java/team/themoment/hellogsmv3/domain/member/service/QueryMemberByIdServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/member/service/QueryMemberByIdServiceTest.java
@@ -11,7 +11,7 @@ import org.springframework.http.HttpStatus;
 import team.themoment.hellogsmv3.domain.member.dto.response.FoundMemberResDto;
 import team.themoment.hellogsmv3.domain.member.entity.Member;
 import team.themoment.hellogsmv3.domain.member.entity.type.Sex;
-import team.themoment.hellogsmv3.domain.member.repo.MemberRepository;
+import team.themoment.hellogsmv3.domain.member.repository.MemberRepository;
 import team.themoment.hellogsmv3.global.exception.error.ExpectedException;
 
 import java.time.LocalDate;

--- a/src/test/java/team/themoment/hellogsmv3/domain/member/service/impl/GenerateCodeServiceImplTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/member/service/impl/GenerateCodeServiceImplTest.java
@@ -8,7 +8,7 @@ import org.mockito.*;
 import org.springframework.http.HttpStatus;
 import team.themoment.hellogsmv3.domain.member.dto.request.GenerateCodeReqDto;
 import team.themoment.hellogsmv3.domain.member.entity.AuthenticationCode;
-import team.themoment.hellogsmv3.domain.member.repo.CodeRepository;
+import team.themoment.hellogsmv3.domain.member.repository.CodeRepository;
 import team.themoment.hellogsmv3.domain.member.service.SendCodeNotificationService;
 import team.themoment.hellogsmv3.global.exception.error.ExpectedException;
 

--- a/src/test/java/team/themoment/hellogsmv3/domain/member/service/impl/GenerateTestCodeServiceImplTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/member/service/impl/GenerateTestCodeServiceImplTest.java
@@ -7,7 +7,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.*;
 import team.themoment.hellogsmv3.domain.member.dto.request.GenerateCodeReqDto;
 import team.themoment.hellogsmv3.domain.member.entity.AuthenticationCode;
-import team.themoment.hellogsmv3.domain.member.repo.CodeRepository;
+import team.themoment.hellogsmv3.domain.member.repository.CodeRepository;
 
 import java.util.Optional;
 


### PR DESCRIPTION
## 개요

애플리케이션 내에서 레포지터리의 역할을 수행하는 인터페이스,클래스들이 담겨있는 패키지의 명칭이 위치마다 `repo`,`repository`로 이원화 되어 있던 것을 단일화하였습니다

## 본문

애플리케이션 내에서 레포지터리의 역할을 수행하는 인터페이스,클래스들이 담겨있는 패키지의 명칭을 </b>`repository`</b>로 통일하였습니다