### PR TITLE
[oneseo]: 

### DIFF
--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/UploadExcelService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/UploadExcelService.java
@@ -15,10 +15,7 @@ import team.themoment.hellogsmv3.global.exception.error.ExpectedException;
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
 
 @Service
@@ -28,56 +25,61 @@ public class UploadExcelService {
     private final EntranceTestResultRepository entranceTestResultRepository;
     private final OneseoRepository oneseoRepository;
 
+    private static final DataFormatter DATA_FORMATTER = new DataFormatter();
+
     @Getter
     private enum CellIndex {
         EXAMINATION_NUMBER(0),
         COMPETENCY_EVALUATION_SCORE(1),
         INTERVIEW_SCORE(2);
         private final int index;
-        CellIndex(int index) {
-            this.index = index;
-        }
+        CellIndex(int index) { this.index = index; }
     }
 
     public void execute(MultipartFile file) {
-        Workbook workbook = createWorkbookFromFile(file);
-        Sheet sheet = workbook.getSheetAt(0);
-        Map<String,SecondTestResultDto> excelResults = getExcelTestResult(sheet);
+        try (Workbook workbook = createWorkbookFromFile(file)) {
+            Sheet sheet = workbook.getNumberOfSheets() == 0 ? null : workbook.getSheetAt(0);
+            if (sheet == null) {
+                throw new ExpectedException("엑셀 첫 번째 시트를 찾을 수 없습니다.", HttpStatus.BAD_REQUEST);
+            }
+            Map<String, SecondTestResultDto> excelResults = getExcelTestResult(sheet, workbook);
 
-        Set<String> examinationNumberToProcess = excelResults.keySet();
-        Map<String, EntranceTestResult> queryResult = oneseoRepository.findEntranceTestResultByExaminationNumbersIn(examinationNumberToProcess.stream().toList());
+            Set<String> examinationNumberToProcess = excelResults.keySet();
+            Map<String, EntranceTestResult> queryResult = oneseoRepository
+                    .findEntranceTestResultByExaminationNumbersIn(examinationNumberToProcess.stream().toList());
 
-        validateNotFoundExaminationNumbers(examinationNumberToProcess, queryResult.keySet());
-
-        saveAllEntranceTestResults(queryResult, excelResults);
+            validateNotFoundExaminationNumbers(examinationNumberToProcess, queryResult.keySet());
+            saveAllEntranceTestResults(queryResult, excelResults);
+        } catch (IOException e) {
+            throw new ExpectedException("엑셀 파일을 읽는 데 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR);
+        }
     }
 
-    private Map<String,SecondTestResultDto> getExcelTestResult(Sheet sheet){
-        Map<String,SecondTestResultDto> excelResults = new HashMap<>();
+    private Map<String, SecondTestResultDto> getExcelTestResult(Sheet sheet, Workbook wb) {
+        Map<String, SecondTestResultDto> excelResults = new HashMap<>();
         Set<String> seenExaminationNumbers = new HashSet<>();
         Set<String> duplicateExaminationNumbers = new HashSet<>();
-        // 0번쨰 행은 헤더
-        for(int i = 1;i<=sheet.getLastRowNum();i++) {
+        FormulaEvaluator evaluator = wb.getCreationHelper().createFormulaEvaluator();
+        for (int i = 1; i <= sheet.getLastRowNum(); i++) {
             Row row = sheet.getRow(i);
-            if(row == null) continue;
+            if (row == null) continue;
 
-            String examinationNumber = readCell(row, CellIndex.EXAMINATION_NUMBER);
-            BigDecimal competencyEvaluationScore = readScoreCell(row, CellIndex.COMPETENCY_EVALUATION_SCORE);
-            BigDecimal interviewScore = readScoreCell(row, CellIndex.INTERVIEW_SCORE);
+            String examinationNumber = readTextCell(row, CellIndex.EXAMINATION_NUMBER, i, evaluator);
+            BigDecimal competencyEvaluationScore = readScoreCell(row, CellIndex.COMPETENCY_EVALUATION_SCORE, i, evaluator);
+            BigDecimal interviewScore = readScoreCell(row, CellIndex.INTERVIEW_SCORE, i, evaluator);
 
-            if(!seenExaminationNumbers.add(examinationNumber)){
+            if (!seenExaminationNumbers.add(examinationNumber)) {
                 duplicateExaminationNumbers.add(examinationNumber);
             }
-
             excelResults.put(examinationNumber, new SecondTestResultDto(competencyEvaluationScore, interviewScore));
         }
-        if(!duplicateExaminationNumbers.isEmpty()){
+        if (!duplicateExaminationNumbers.isEmpty()) {
             throw new ExpectedException("다음 수험번호가 중복되었습니다: " + String.join(", ", duplicateExaminationNumbers), HttpStatus.BAD_REQUEST);
         }
         return excelResults;
     }
 
-    private void validateNotFoundExaminationNumbers(Set<String> expected,Set<String> found){
+    private void validateNotFoundExaminationNumbers(Set<String> expected, Set<String> found) {
         Set<String> notFoundExaminationNumbers = expected.stream()
                 .filter(examinationNumber -> !found.contains(examinationNumber))
                 .collect(Collectors.toSet());
@@ -89,36 +91,58 @@ public class UploadExcelService {
     private void saveAllEntranceTestResults(Map<String, EntranceTestResult> resultToModify,
                                             Map<String, SecondTestResultDto> excelResults) {
         resultToModify.forEach((examinationNumber, entranceTestResult) -> {
-            entranceTestResult.modifyCompetencyEvaluationScore(excelResults.get(examinationNumber).competencyEvaluationScore());
-            entranceTestResult.modifyInterviewScore(excelResults.get(examinationNumber).interviewScore());
+            SecondTestResultDto dto = excelResults.get(examinationNumber);
+            entranceTestResult.modifyCompetencyEvaluationScore(dto.competencyEvaluationScore());
+            entranceTestResult.modifyInterviewScore(dto.interviewScore());
         });
         entranceTestResultRepository.saveAll(resultToModify.values());
     }
 
-    private Workbook createWorkbookFromFile(MultipartFile file){
+    private Workbook createWorkbookFromFile(MultipartFile file) throws IOException {
         if (file.isEmpty()) {
             throw new ExpectedException("엑셀 파일이 비어있습니다.", HttpStatus.BAD_REQUEST);
         }
-        try {
-            return WorkbookFactory.create(file.getInputStream());
-        } catch (IOException e) {
-            throw new ExpectedException("엑셀 파일을 읽는 데 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR);
-        }
+        return WorkbookFactory.create(file.getInputStream());
     }
-    private BigDecimal readScoreCell(Row row, CellIndex cellIndex) {
-        String cellValue = readCell(row, cellIndex);
-        BigDecimal score = new BigDecimal(cellValue).setScale(2, RoundingMode.HALF_UP);
-        if(score.compareTo(BigDecimal.ZERO) < 0 || score.compareTo(new BigDecimal("100")) > 0) {
-            throw new ExpectedException("점수는 0 이상 100 이하의 값이어야 합니다.", HttpStatus.BAD_REQUEST);
+
+    private BigDecimal readScoreCell(Row row, CellIndex cellIndex, int rowIdx, FormulaEvaluator evaluator) {
+        String raw = readTextCell(row, cellIndex, rowIdx, evaluator);
+        BigDecimal score;
+        try {
+            score = new BigDecimal(raw);
+        } catch (NumberFormatException e) {
+            throw new ExpectedException(positionMsg(rowIdx, cellIndex, "점수 형식이 올바르지 않습니다."), HttpStatus.BAD_REQUEST);
+        }
+        score = score.setScale(2, RoundingMode.HALF_UP);
+        if (score.compareTo(BigDecimal.ZERO) < 0 || score.compareTo(new BigDecimal("100")) > 0) {
+            throw new ExpectedException(positionMsg(rowIdx, cellIndex, "점수는 0 이상 100 이하의 값이어야 합니다."), HttpStatus.BAD_REQUEST);
         }
         return score;
     }
-    private String readCell(Row row, CellIndex cellIndex){
-        if (row.getCell(cellIndex.getIndex()) == null) {
-            throw new ExpectedException("엑셀 파일에 필수 정보가 누락되었습니다.", HttpStatus.BAD_REQUEST);
-        }else if(row.getCell(cellIndex.getIndex()).getCellType() != CellType.STRING){
-            throw new ExpectedException("엑셀 파일의 셀 타입이 잘못되었습니다. 문자열 타입이어야 합니다.", HttpStatus.BAD_REQUEST);
+
+    private String readTextCell(Row row, CellIndex cellIndex, int rowIdx, FormulaEvaluator evaluator) {
+        Cell cell = row.getCell(cellIndex.getIndex());
+        if (cell == null || cell.getCellType() == CellType.BLANK) {
+            throw new ExpectedException(positionMsg(rowIdx, cellIndex, "필수 셀이 비어있습니다."), HttpStatus.BAD_REQUEST);
         }
-        return row.getCell(cellIndex.getIndex()).getStringCellValue();
+        String value;
+        if (cell.getCellType() == CellType.FORMULA) {
+            value = DATA_FORMATTER.formatCellValue(cell, evaluator);
+        } else if (cell.getCellType() == CellType.NUMERIC) {
+            value = DATA_FORMATTER.formatCellValue(cell);
+        } else {
+            value = cell.getCellType() == CellType.STRING ? cell.getStringCellValue() : DATA_FORMATTER.formatCellValue(cell);
+        }
+        value = value.trim();
+        if (value.isEmpty()) {
+            throw new ExpectedException(positionMsg(rowIdx, cellIndex, "필수 셀이 비어있습니다."), HttpStatus.BAD_REQUEST);
+        }
+        return value;
+    }
+
+    private String positionMsg(int rowIdx, CellIndex cellIndex, String msg) {
+        int displayRow = rowIdx + 1;
+        char col = (char) ('A' + cellIndex.getIndex());
+        return msg + " (위치: " + col + displayRow + ")";
     }
 }


### PR DESCRIPTION
## 개요

UploadExcelService 에서 문자열만 허용하던 점수/수험번호 파싱을 숫자·수식까지 허용하도록 개선하고 BigDecimal  검증을 강화했습니다,또한 선생님께서 해당 기능을 사용하시며 발생 가능한 실수까지 핸들링 하도록 추가적인 핸들링을 하였습니다.

## 본문

기존 문제점
- 모든 셀 타입을 STRING 으로 강제 → 실제 Excel 숫자 셀(일반 입력) 업로드 시 즉시 실패
주요 변경
- 셀 타입 허용 확장: STRING / NUMERIC / FORMULA 읽기 (DataFormatter + FormulaEvaluator)
- 표시값 문자열화 후 BigDecimal 생성 → 오차 안정성 + 사용자 UI 표시와 일치
- 점수 범위(0~100) + scale(2) 반올림(HALF_UP) 적용
- 중복 수험번호 수집 후 일괄 예외
- 빈 행/BLANK 셀 skip 및 위치(A열+행번호) 포함 에러 메시지
- try-with-resources 로 Workbook 자원 해제

### 변경 - optional

기존에 있던 무언가가 변경된 경우

### 피드백 - optional

본인이 작성한 코드에 대해서 피드백이 필요한 경우

### 사용방법 - optional

사용방법이 복잡하여 다른 이들이 사용하기 어렵다고 판단되는 경우, 사용방법을 자세하게 설명

### 기타

DataFormatter 사용으로 매우 큰 숫자/지수 표기 시 기대와 다를 수 있으나 점수/수험번호 도메인 범위에서는 영향이 없을 것 같습니다
