### PR TITLE
[global] 알려진 취약점을 가진 종속선 버전 변경

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -97,7 +97,7 @@ clean {
     delete file(querydslSrcDir)
 }
 
-tasks.withType(JavaCompile) {
+tasks.withType(JavaCompile).configureEach {
     options.generatedSourceOutputDirectory = file(querydslSrcDir)
 }
 


### PR DESCRIPTION
## 개요

알려진 취약점을 가진 종속성들의 버전을 올려 취약점을 해결하였습니다.또한 불필요한 구성을 야기할 수 있는 설정을 개선하였습니다

## 본문

- `net.minidev.json-smart`
- `org.apache.poi.poi-ooxml`
위 2가지 종속성이 알려진 취약점을 가지고 있어 이들이 해결된 버전으로 변경하였습니다

---

<b>`net.minidev.json-smart`</b>의 경우 **CVE-2024-57699** 취약점이 보고되어 다수의 `{` 문자가 입력된 JSON을 받을 경우 Stack Exhaustion, 즉 **가용 가능한 스택을 전부 소진**하는 공격이 가능하여 악의적인 목적으로 [DoS 공격](https://www.paloaltonetworks.co.kr/cyberpedia/what-is-a-denial-of-service-attack-dos)이 가능하였습니다.이 경우 `json-smart` 종속성이 제공하는 함수로 관련 처리를 하기 전에 방어 로직으로 충분히 방어가 가능하지만 해당 문제가 완전히 해결된 `2.5.2` 버전으로 변경하여 근본적인 문제를 해결하도록 하였습니다

---

<b>`org.apache.poi.poi-ooxml`</b>의 경우 **CVE-2024-25710**,**CVE-2024-26308**,**CVE-2025-31672** 취약점이 보고되었습니다.
**CVE-2024-25710** 취약점의 경우 해당 종속성에서 내부적으로 참조하는 `Apache Commons Compress` 종속성에서 발생한 취약점으로 해당 종속성의 특정 함수 내에서 도달할 수 없는 종료지점, 즉 **무한 루프** 문제가 있는 것입니다
**CVE-2024-26308** 취약점은 역시 `Apache Commons Compress` 종속성에서 **제한 없이 컴퓨팅 자원을 할당** 받을 수 있는 취약점 입니다.
**CVE-2025-31672** 취약점은 zip 파일과 관련한 문제로 악의적인 사용자가 zip 파일 내부에 동일한 이름을 가진 zip 파일을 n개 더 넣어놓는다면 Apache POI가 이를 파싱하며 서로 다른 zip 파일을 참조하게 되며 **다른 내용을 읽고 사용**하게 될 수 있습니다.

이러한 취약점들을 개선한 `5.4.1`로 변경하여 문제를 방지하였습니다

---


추가적으로 불필요하고 중복된 구성을 포함할 수 있는 명령문을 개선하였습니다
```gradle
tasks.withType(JavaCompile) {
    options.generatedSourceOutputDirectory = file(querydslSrcDir)
}
```
기존엔 해당 설정이 빌드 될 때 곧바로 포함되어 중복되고 무의미한 구성이 될 수 있었지만 이를 개선해 
```groovy
tasks.withType(JavaCompile).configureEach {
    options.generatedSourceOutputDirectory = file(querydslSrcDir)
}
```
필요 시에만 구성되도록 변경하였습니다

### 기타

- `com.querydsl:querydsl-jpa`
- `com.querydsl:querydsl-apt`
위 2개 종속성에도 알려진 취약점 **CVE-2024-49203**,**CVE-2021-47621**이 있어 `orderBy`에 대한 [SQL 주입](https://developer.mozilla.org/ko/docs/Glossary/SQL_Injection) 공격과 [XXE 공격](https://binwalk.tistory.com/118)이 가능하지만 해당 취약점은 로직을 구현할 때 충분히 방어할 수 있으며 이를 개선한 버전 역시 출시되지 않아 해결하지 않았습니다

- `org.apache.poi.poi-ooxml`
위 종속성의 변경된 버전 `5.4.1`에도 **CVE-2025-48924** 취약점이 보고되어 있지만 해당 취약점을 해결한 버전이 출시되지 않아 개선하지 않았습니다.
