### PR TITLE
[auth] 세션 유지시간 연장

### DIFF
--- a/src/main/java/team/themoment/hellogsmv3/global/security/auth/service/OAuthAuthenticationService.java
+++ b/src/main/java/team/themoment/hellogsmv3/global/security/auth/service/OAuthAuthenticationService.java
@@ -4,6 +4,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
@@ -24,6 +25,7 @@ import team.themoment.hellogsmv3.global.security.auth.service.provider.OAuthProv
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 import java.time.LocalDateTime;
+import java.time.Duration;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -36,6 +38,9 @@ public class OAuthAuthenticationService {
 
     private final OAuthProviderFactory oAuthProviderFactory;
     private final MemberRepository memberRepository;
+
+    @Value("${spring.session.timeout:${server.servlet.session.timeout}}")
+    private Duration sessionTimeout;
 
     public void execute(String provider, String code, HttpServletRequest request) {
 
@@ -113,6 +118,6 @@ public class OAuthAuthenticationService {
         SecurityContextHolder.setContext(securityContext);
         session.setAttribute(HttpSessionSecurityContextRepository.SPRING_SECURITY_CONTEXT_KEY, securityContext);
 
-        session.setMaxInactiveInterval(3600);
+        session.setMaxInactiveInterval((int) sessionTimeout.getSeconds());
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -7,7 +7,7 @@ server:
       enabled: true
       force: true
     session:
-      timeout: 3600
+      timeout: 7200
       cookie:
         name: SESSION
         http-only: true

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -42,7 +42,7 @@ spring:
     redis:
       flush-mode: on-save
       save-mode: on-set-attribute
-    timeout: 3600s
+    timeout: 7200s
 
   security:
     oauth2:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -7,12 +7,12 @@ server:
       enabled: true
       force: true
     session:
-      timeout: 7200
+      timeout: 10800
       cookie:
         name: SESSION
         http-only: true
         path: /
-        max-age: 7200
+        max-age: 10800
 
 logging:
   config: classpath:logback-spring.xml
@@ -42,7 +42,7 @@ spring:
     redis:
       flush-mode: on-save
       save-mode: on-set-attribute
-    timeout: 7200s
+    timeout: 10800s
 
   security:
     oauth2:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -12,7 +12,7 @@ server:
         name: SESSION
         http-only: true
         path: /
-        max-age: 3600
+        max-age: 7200
 
 logging:
   config: classpath:logback-spring.xml

--- a/src/test/java/team/themoment/hellogsmv3/domain/security/auth/service/OAuthAuthenticationServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/security/auth/service/OAuthAuthenticationServiceTest.java
@@ -26,6 +26,8 @@ import team.themoment.hellogsmv3.global.security.auth.service.OAuthProviderFacto
 import team.themoment.hellogsmv3.global.security.auth.service.provider.OAuthProvider;
 import team.themoment.hellogsmv3.global.security.auth.dto.UserAuthInfo;
 
+import java.time.Duration;
+import org.springframework.test.util.ReflectionTestUtils;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -58,6 +60,7 @@ class OAuthAuthenticationServiceTest {
     void setUp() {
         MockitoAnnotations.openMocks(this);
         oAuthAuthenticationService = new OAuthAuthenticationService(oAuthProviderFactory, memberRepository);
+        ReflectionTestUtils.setField(oAuthAuthenticationService, "sessionTimeout", Duration.ofSeconds(3600));
     }
 
     @Nested

--- a/src/test/java/team/themoment/hellogsmv3/domain/security/auth/service/OAuthAuthenticationServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/security/auth/service/OAuthAuthenticationServiceTest.java
@@ -60,7 +60,7 @@ class OAuthAuthenticationServiceTest {
     void setUp() {
         MockitoAnnotations.openMocks(this);
         oAuthAuthenticationService = new OAuthAuthenticationService(oAuthProviderFactory, memberRepository);
-        ReflectionTestUtils.setField(oAuthAuthenticationService, "sessionTimeout", Duration.ofSeconds(3600));
+        ReflectionTestUtils.setField(oAuthAuthenticationService, "sessionTimeout", Duration.ofSeconds(10800));
     }
 
     @Nested
@@ -135,7 +135,7 @@ class OAuthAuthenticationServiceTest {
 
                     mockSecurityContextHolder.verify(() -> SecurityContextHolder.setContext(securityContext));
                     verify(session).setAttribute(HttpSessionSecurityContextRepository.SPRING_SECURITY_CONTEXT_KEY, securityContext);
-                    verify(session).setMaxInactiveInterval(3600);
+                    verify(session).setMaxInactiveInterval(10800);
                 }
             }
         }
@@ -202,7 +202,7 @@ class OAuthAuthenticationServiceTest {
 
                     mockSecurityContextHolder.verify(() -> SecurityContextHolder.setContext(securityContext));
                     verify(session).setAttribute(HttpSessionSecurityContextRepository.SPRING_SECURITY_CONTEXT_KEY, securityContext);
-                    verify(session).setMaxInactiveInterval(3600);
+                    verify(session).setMaxInactiveInterval(10800);
                 }
             }
         }
@@ -259,7 +259,7 @@ class OAuthAuthenticationServiceTest {
 
                     verify(request).getSession(true);
                     verify(newSession).setAttribute(HttpSessionSecurityContextRepository.SPRING_SECURITY_CONTEXT_KEY, securityContext);
-                    verify(newSession).setMaxInactiveInterval(3600);
+                    verify(newSession).setMaxInactiveInterval(10800);
 
                     mockSecurityContextHolder.verify(() -> SecurityContextHolder.setContext(securityContext));
                 }
@@ -310,7 +310,7 @@ class OAuthAuthenticationServiceTest {
                     verify(request).getSession(false);
                     verify(request).getSession(true);
                     verify(newSession).setAttribute(HttpSessionSecurityContextRepository.SPRING_SECURITY_CONTEXT_KEY, securityContext);
-                    verify(newSession).setMaxInactiveInterval(3600);
+                    verify(newSession).setMaxInactiveInterval(10800);
 
                     mockSecurityContextHolder.verify(() -> SecurityContextHolder.setContext(securityContext));
                 }
@@ -367,7 +367,7 @@ class OAuthAuthenticationServiceTest {
 
                     assertTrue(oAuthToken.getAuthorities().contains(new SimpleGrantedAuthority(Role.UNAUTHENTICATED.name())));
 
-                    verify(session).setMaxInactiveInterval(3600);
+                    verify(session).setMaxInactiveInterval(10800);
                     mockSecurityContextHolder.verify(() -> SecurityContextHolder.setContext(securityContext));
                 }
             }


### PR DESCRIPTION
## 개요

세션 만료 시간을 3시간으로 연장하였으며 기존에 서비스 코드에서 하드코딩된 세션 만료시간을 프로파일에서 주입받아 사용할 수 있도록 하였습니다

## 본문

기존에 로그인 유지 시간이 짧다는 불만사항이 있어 이를 반영해 세션 만료시간을 3시간으로 연장하였습니다.`OAuthAuthenticationService`에서도 `@Value`어노테이션으로 프로파일의 ``spring.session.timeout`` 또는 ``server.servlet.session.timeout`` 프로퍼티의 값을 세션에 설정하도록 하였습니다