### PR TITLE
[thirdParty] 본인인증 SMS 메세지 본문 변경

### DIFF
--- a/src/main/java/team/themoment/hellogsmv3/global/thirdParty/aws/sns/impl/SendCodeNotificationServiceImpl.java
+++ b/src/main/java/team/themoment/hellogsmv3/global/thirdParty/aws/sns/impl/SendCodeNotificationServiceImpl.java
@@ -21,6 +21,6 @@ public class SendCodeNotificationServiceImpl implements SendCodeNotificationServ
     }
 
     private static String createFooterMessage() {
-        return "본인이 요청한게 아니라면 교무실 062-949-6843 으로 문의해주세요.";
+        return "본인이 요청한 경우가 아니라면 교무실 062-949-6843 으로 문의해주세요.";
     }
 }


### PR DESCRIPTION
## 개요

4차 원서 작성 테스트 후 [선생님의 요구사항](https://www.notion.so/4-2025-08-28-25d3f725618580e38fe7fea4a97d96f6?source=copy_link)을 반영하여 본인인증 SMS 메세지의 본문을 변경하였습니다

## 본문

기존에는 본인인증 SMS 메세지에서 본인이 요청하지 않았을 경우를 가정하여 알림성 메세지를 보내줄 때 다음과 같은 본문 내용으로 보내주었습니다
```
본인이 요청한게 아니라면 교무실 062-949-6843 으로 문의해주세요.
```
해당 내용을 선생님의 요구사항에 맞게 다음과 같이 수정하였습니다.
```
본인이 요청한 경우가 아니라면 교무실 062-949-6843 으로 문의해주세요.
```
