### PR TITLE
[auth] Kakao OAuth 인증 과정 중 `email`유효하지 않을 시 `id` 사용

### DIFF
--- a/src/main/java/team/themoment/hellogsmv3/global/security/auth/service/provider/KakaoOAuthProvider.java
+++ b/src/main/java/team/themoment/hellogsmv3/global/security/auth/service/provider/KakaoOAuthProvider.java
@@ -43,10 +43,11 @@ public class KakaoOAuthProvider implements OAuthProvider {
         KakaoTokenResDto tokenResponse = exchangeCodeForToken(authorizationCode, clientRegistration);
         KakaoUserInfoResDto userInfo = getUserInfo(tokenResponse.accessToken());
         
-        String email = extractUserEmail(userInfo);
-        validateUserEmail(email);
+        String providerId = extractUserEmail(userInfo);
+        providerId = providerId == null ? userInfo.id().toString() : providerId;
+        validateUserEmail(providerId);
         
-        return new UserAuthInfo(email, PROVIDER_NAME, getAuthReferrerType());
+        return new UserAuthInfo(providerId, PROVIDER_NAME, getAuthReferrerType());
     }
     
     private void validateAuthorizationCode(String code) {


### PR DESCRIPTION
## 개요

Kakao OAuth 사용 시 사용자가 유효하지 않은 `email`을 갖고 있다면 `id`를 사용하도록 수정하였습니다
## 본문

- #208 해당 PR에서 적용되었던 변경사항이
- #243 PR에서 OAuth 인증 로직이 대폭 변경되며 포함되지 않았었는데 해당 변경사항을 반영하였습니다.