### PR TITLE
[oneseo] 중복된 과목이름 유효성검사 추가

### DIFF
--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/annotation/SubjectNameValidator.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/annotation/SubjectNameValidator.java
@@ -1,0 +1,38 @@
+package team.themoment.hellogsmv3.domain.oneseo.annotation;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import team.themoment.hellogsmv3.domain.oneseo.dto.request.MiddleSchoolAchievementReqDto;
+
+import java.util.Collections;
+
+public class SubjectNameValidator implements ConstraintValidator<ValidSubjectName, MiddleSchoolAchievementReqDto> {
+
+    private ValidSubjectName annotation;
+
+    @Override
+    public void initialize(ValidSubjectName constraintAnnotation) {
+        this.annotation = constraintAnnotation;
+    }
+
+    @Override
+    public boolean isValid(MiddleSchoolAchievementReqDto middleSchoolAchievementReqDto, ConstraintValidatorContext context) {
+        boolean isValid = Collections.disjoint(
+                middleSchoolAchievementReqDto.generalSubjects(),
+                middleSchoolAchievementReqDto.newSubjects()
+        ) && Collections.disjoint(
+                middleSchoolAchievementReqDto.artsPhysicalSubjects(),
+                middleSchoolAchievementReqDto.newSubjects()
+        ) && Collections.disjoint(
+                middleSchoolAchievementReqDto.artsPhysicalSubjects(),
+                middleSchoolAchievementReqDto.generalSubjects()
+        );
+
+        if(!isValid){
+            context.disableDefaultConstraintViolation();
+            context.buildConstraintViolationWithTemplate(annotation.message()).addConstraintViolation();
+            return false;
+        }
+        return true;
+    }
+}

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/annotation/ValidSubjectName.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/annotation/ValidSubjectName.java
@@ -1,0 +1,18 @@
+package team.themoment.hellogsmv3.domain.oneseo.annotation;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Constraint(validatedBy = SubjectNameValidator.class)
+@Target({ ElementType.FIELD, ElementType.TYPE })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ValidSubjectName {
+    String message() default "중복된 이름의 과목이 입력되었습니다.";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/controller/OneseoController.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/controller/OneseoController.java
@@ -147,7 +147,7 @@ public class OneseoController {
     @Operation(summary = "모의 성적 계산", description = "성적 점수를 입력받아 모의 성적 환산값을 반환합니다.")
     @PostMapping("/calculate-mock-score")
     public CalculatedScoreResDto calcMockScore(
-            @RequestBody MiddleSchoolAchievementReqDto dto,
+            @Valid @RequestBody MiddleSchoolAchievementReqDto dto,
             @RequestParam("graduationType") GraduationType graduationType
     ) {
         return calculateMockScoreService.execute(dto, graduationType);

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/dto/request/MiddleSchoolAchievementReqDto.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/dto/request/MiddleSchoolAchievementReqDto.java
@@ -2,11 +2,13 @@ package team.themoment.hellogsmv3.domain.oneseo.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
+import team.themoment.hellogsmv3.domain.oneseo.annotation.ValidSubjectName;
 
 import java.math.BigDecimal;
 import java.util.List;
 
 @Builder
+@ValidSubjectName
 /**  중학교 성적 Request DTO
  *   Request 용도로만 사용되어야 하고, 아직 성적이 복사되지 않은 상태의 DTO입니다.
  */

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/dto/request/OneseoReqDto.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/dto/request/OneseoReqDto.java
@@ -1,6 +1,7 @@
 package team.themoment.hellogsmv3.domain.oneseo.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
@@ -64,6 +65,7 @@ public record OneseoReqDto(
         @NotNull
         Major thirdDesiredMajor,
 
+        @Valid
         MiddleSchoolAchievementReqDto middleSchoolAchievement,
 
         @Schema(description = "중학교 이름", nullable = true, defaultValue = "금호중앙중학교")

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/dto/request/OneseoTempReqDto.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/dto/request/OneseoTempReqDto.java
@@ -1,6 +1,7 @@
 package team.themoment.hellogsmv3.domain.oneseo.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
@@ -52,6 +53,7 @@ public record OneseoTempReqDto(
         @Schema(description = "3지망 학과", defaultValue = "IOT", allowableValues = {"SW", "AI", "IOT"})
         Major thirdDesiredMajor,
 
+        @Valid
         MiddleSchoolAchievementReqDto middleSchoolAchievement,
 
         @Schema(description = "중학교 이름", nullable = true, defaultValue = "금호중앙중학교")

--- a/src/test/java/team/themoment/hellogsmv3/domain/oneseo/annotation/SubjectNameValidatorTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/oneseo/annotation/SubjectNameValidatorTest.java
@@ -1,0 +1,90 @@
+package team.themoment.hellogsmv3.domain.oneseo.annotation;
+
+import jakarta.validation.ConstraintValidatorContext;
+import org.junit.jupiter.api.*;
+import org.mockito.Mockito;
+import team.themoment.hellogsmv3.domain.oneseo.dto.request.MiddleSchoolAchievementReqDto;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@DisplayName("SubjectNameValidator 클래스의")
+public class SubjectNameValidatorTest {
+
+    @DisplayName("isValid 메소드는")
+    @Nested
+    class Describe_isValid {
+
+        SubjectNameValidator validator;
+        ConstraintValidatorContext context;
+        MiddleSchoolAchievementReqDto middleSchoolAchievementReqDto;
+        ValidSubjectName annotation;
+
+        @BeforeEach
+        void setUp() {
+            validator = new SubjectNameValidator();
+            @ValidSubjectName
+            class Dummy {}
+            annotation = Dummy.class.getAnnotation(ValidSubjectName.class);
+            validator.initialize(annotation);
+            context = Mockito.mock(ConstraintValidatorContext.class);
+            ConstraintValidatorContext.ConstraintViolationBuilder builder = Mockito.mock(ConstraintValidatorContext.ConstraintViolationBuilder.class);
+            when(context.buildConstraintViolationWithTemplate(anyString())).thenReturn(builder);
+            when(builder.addConstraintViolation()).thenReturn(context);
+        }
+
+        @DisplayName("모든 과목이 중복되지 않으면")
+        @Nested
+        class Context_with_no_duplicate_subjects {
+
+            @BeforeEach
+            void setUp() {
+                List<String> generalSubjects = Arrays.asList("국어", "도덕", "사회", "역사", "수학", "과학", "기술가정", "영어");
+                List<String> newSubjects = Arrays.asList("프로그래밍");
+                List<String> artsPhysicalSubjects = Arrays.asList("체육", "미술", "음악");
+
+                middleSchoolAchievementReqDto = MiddleSchoolAchievementReqDto.builder()
+                        .generalSubjects(generalSubjects)
+                        .newSubjects(newSubjects)
+                        .artsPhysicalSubjects(artsPhysicalSubjects)
+                        .build();
+            }
+
+            @DisplayName("ConstraintViolation을 발생시키지 않는다.")
+            @Test
+            void it_doesnt_make_constraint_violation() {
+                boolean result = validator.isValid(middleSchoolAchievementReqDto, context);
+                assertTrue(result);
+            }
+        }
+
+        @DisplayName("중복된 과목이 있으면")
+        @Nested
+        class Context_with_multiple_duplicates {
+
+            @BeforeEach
+            void setUp() {
+                List<String> generalSubjects = Arrays.asList("국어", "도덕", "사회", "역사", "수학", "과학", "기술가정", "영어");
+                List<String> newSubjects = Arrays.asList("수학", "체육");
+                List<String> artsPhysicalSubjects = Arrays.asList("체육", "미술", "음악");
+
+                middleSchoolAchievementReqDto = MiddleSchoolAchievementReqDto.builder()
+                        .generalSubjects(generalSubjects)
+                        .newSubjects(newSubjects)
+                        .artsPhysicalSubjects(artsPhysicalSubjects)
+                        .build();
+            }
+
+            @DisplayName("ConstraintViolation을 발생시킨다.")
+            @Test
+            void it_makes_constraint_violation() {
+                boolean result = validator.isValid(middleSchoolAchievementReqDto, context);
+                assertFalse(result);
+                verify(context).buildConstraintViolationWithTemplate(annotation.message());
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 개요

중복된 과목이름에 대한 유효성검사를 추가했습니다.

## 본문

추가과목을 입력할 수 있는 기능 때문에, 같은 과목을 여러번 입력 할 수 있는 가능성이 있었습니다. 이를 해결하기 위해 중복된 과목 이름에 대해 유효성 검사를 추가했습니다.

MiddleSchoolAchievementReqDto의 generalSubjects, newSubjects, artsPhysicalSubjects는 각각 일반교과 과목, 추가교과 과목, 예체능 교과 과목을 나타내는 문자열 리스트입니다.
서로 하나라도 중복된 과목이름이 감지되면, Validator에서 "중복된 이름의 과목이 입력되었습니다."라는 메세지를 나타내도록 하였습니다.
