### PR TITLE
[oneseo] 중복 과목명 validation에서 발생한 NPE 해결

### DIFF
--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/annotation/SubjectNameValidator.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/annotation/SubjectNameValidator.java
@@ -2,7 +2,9 @@ package team.themoment.hellogsmv3.domain.oneseo.annotation;
 
 import jakarta.validation.ConstraintValidator;
 import jakarta.validation.ConstraintValidatorContext;
+import org.springframework.http.HttpStatus;
 import team.themoment.hellogsmv3.domain.oneseo.dto.request.MiddleSchoolAchievementReqDto;
+import team.themoment.hellogsmv3.global.exception.error.ExpectedException;
 
 import java.util.Collections;
 
@@ -17,6 +19,13 @@ public class SubjectNameValidator implements ConstraintValidator<ValidSubjectNam
 
     @Override
     public boolean isValid(MiddleSchoolAchievementReqDto middleSchoolAchievementReqDto, ConstraintValidatorContext context) {
+        if(middleSchoolAchievementReqDto == null ||
+                middleSchoolAchievementReqDto.generalSubjects() == null ||
+                middleSchoolAchievementReqDto.artsPhysicalSubjects() == null ||
+                middleSchoolAchievementReqDto.newSubjects() == null
+        ){
+            throw new ExpectedException("과목명이 입력되지 않았습니다.", HttpStatus.BAD_REQUEST);
+        }
         boolean isValid = Collections.disjoint(
                 middleSchoolAchievementReqDto.generalSubjects(),
                 middleSchoolAchievementReqDto.newSubjects()

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/annotation/SubjectNameValidator.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/annotation/SubjectNameValidator.java
@@ -18,11 +18,11 @@ public class SubjectNameValidator implements ConstraintValidator<ValidSubjectNam
     @Override
     public boolean isValid(MiddleSchoolAchievementReqDto middleSchoolAchievementReqDto, ConstraintValidatorContext context) {
 
-        if(
+        if (
                 middleSchoolAchievementReqDto.generalSubjects() == null ||
-                middleSchoolAchievementReqDto.artsPhysicalSubjects() == null||
+                middleSchoolAchievementReqDto.artsPhysicalSubjects() == null ||
                 middleSchoolAchievementReqDto.newSubjects() == null
-        ){
+        ) {
             return true;
         }
 
@@ -37,7 +37,7 @@ public class SubjectNameValidator implements ConstraintValidator<ValidSubjectNam
                 middleSchoolAchievementReqDto.generalSubjects()
         );
 
-        if(!isValid){
+        if (!isValid) {
             context.disableDefaultConstraintViolation();
             context.buildConstraintViolationWithTemplate(annotation.message()).addConstraintViolation();
             return false;

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/annotation/SubjectNameValidator.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/annotation/SubjectNameValidator.java
@@ -21,11 +21,14 @@ public class SubjectNameValidator implements ConstraintValidator<ValidSubjectNam
     public boolean isValid(MiddleSchoolAchievementReqDto middleSchoolAchievementReqDto, ConstraintValidatorContext context) {
         if(middleSchoolAchievementReqDto == null ||
                 middleSchoolAchievementReqDto.generalSubjects() == null ||
-                middleSchoolAchievementReqDto.artsPhysicalSubjects() == null ||
-                middleSchoolAchievementReqDto.newSubjects() == null
+                middleSchoolAchievementReqDto.artsPhysicalSubjects() == null
         ){
-            throw new ExpectedException("과목명이 입력되지 않았습니다.", HttpStatus.BAD_REQUEST);
+            throw new ExpectedException("middleSchoolAchievementReqDto 입력이 잘못되었습니다.", HttpStatus.BAD_REQUEST);
         }
+        if(middleSchoolAchievementReqDto.newSubjects() == null){
+            return true;
+        }
+
         boolean isValid = Collections.disjoint(
                 middleSchoolAchievementReqDto.generalSubjects(),
                 middleSchoolAchievementReqDto.newSubjects()

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/annotation/SubjectNameValidator.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/annotation/SubjectNameValidator.java
@@ -18,7 +18,11 @@ public class SubjectNameValidator implements ConstraintValidator<ValidSubjectNam
     @Override
     public boolean isValid(MiddleSchoolAchievementReqDto middleSchoolAchievementReqDto, ConstraintValidatorContext context) {
 
-        if(middleSchoolAchievementReqDto.newSubjects() == null){
+        if(
+                middleSchoolAchievementReqDto.generalSubjects() == null ||
+                middleSchoolAchievementReqDto.artsPhysicalSubjects() == null||
+                middleSchoolAchievementReqDto.newSubjects() == null
+        ){
             return true;
         }
 

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/annotation/SubjectNameValidator.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/annotation/SubjectNameValidator.java
@@ -2,9 +2,7 @@ package team.themoment.hellogsmv3.domain.oneseo.annotation;
 
 import jakarta.validation.ConstraintValidator;
 import jakarta.validation.ConstraintValidatorContext;
-import org.springframework.http.HttpStatus;
 import team.themoment.hellogsmv3.domain.oneseo.dto.request.MiddleSchoolAchievementReqDto;
-import team.themoment.hellogsmv3.global.exception.error.ExpectedException;
 
 import java.util.Collections;
 
@@ -19,12 +17,7 @@ public class SubjectNameValidator implements ConstraintValidator<ValidSubjectNam
 
     @Override
     public boolean isValid(MiddleSchoolAchievementReqDto middleSchoolAchievementReqDto, ConstraintValidatorContext context) {
-        if(middleSchoolAchievementReqDto == null ||
-                middleSchoolAchievementReqDto.generalSubjects() == null ||
-                middleSchoolAchievementReqDto.artsPhysicalSubjects() == null
-        ){
-            throw new ExpectedException("middleSchoolAchievementReqDto 입력이 잘못되었습니다.", HttpStatus.BAD_REQUEST);
-        }
+
         if(middleSchoolAchievementReqDto.newSubjects() == null){
             return true;
         }

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/dto/request/OneseoTempReqDto.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/dto/request/OneseoTempReqDto.java
@@ -53,7 +53,6 @@ public record OneseoTempReqDto(
         @Schema(description = "3지망 학과", defaultValue = "IOT", allowableValues = {"SW", "AI", "IOT"})
         Major thirdDesiredMajor,
 
-        @Valid
         MiddleSchoolAchievementReqDto middleSchoolAchievement,
 
         @Schema(description = "중학교 이름", nullable = true, defaultValue = "금호중앙중학교")

--- a/src/test/java/team/themoment/hellogsmv3/domain/oneseo/annotation/SubjectNameValidatorTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/oneseo/annotation/SubjectNameValidatorTest.java
@@ -86,5 +86,27 @@ public class SubjectNameValidatorTest {
                 verify(context).buildConstraintViolationWithTemplate(annotation.message());
             }
         }
+
+        @DisplayName("필요한 필드가 null이면")
+        @Nested
+        class Context_with_null_fields {
+
+            @BeforeEach
+            void setUp() {
+                middleSchoolAchievementReqDto = MiddleSchoolAchievementReqDto.builder()
+                        .generalSubjects(Arrays.asList("국어", "도덕", "사회", "역사", "수학", "과학", "기술가정", "영어"))
+                        .newSubjects(null)
+                        .artsPhysicalSubjects(Arrays.asList("체육", "미술", "음악"))
+                        .build();
+            }
+
+            @DisplayName("ConstraintViolation을 발생시키지 않는다.")
+            @Test
+            void it_doesnt_make_constraint_violation() {
+                boolean result = validator.isValid(middleSchoolAchievementReqDto, context);
+                assertTrue(result);
+            }
+        }
+
     }
 }


### PR DESCRIPTION
## 개요

SubjectNameValidator에서 사용하는 값들이, null일때 발생하던 NPE를 해결했습니다.

## 본문

원서 임시저장의 경우 과목명 필드가 채워지지 않았고 추가과목 필드는 추가과목이 없을시 null 입니다.
SubjectNameValidator에서도 null 값에 대한 예외처리가 없어 NPE가 발생했습니다.
임시저장시 Validation을 수행하지 않도록 하고, Validator에서도 필요한 필드가 null 인경우에 대한 예외처리를 추가했습니다.