### PR TITLE
[utility] 회원탈퇴 API에서 올바르지 않은 Swagger 문서화 수정

### DIFF
--- a/src/main/java/team/themoment/hellogsmv3/domain/common/utility/controller/UtilityController.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/common/utility/controller/UtilityController.java
@@ -49,7 +49,7 @@ public class UtilityController {
     @ApiResponses(value = {
             @ApiResponse(
                     responseCode = "200",
-                    description = "원서 삭제 성공"
+                    description = "회원탈퇴 및 해당하는 계정의 원서 삭제 성공"
             ),
             @ApiResponse(
                     responseCode = "404",


### PR DESCRIPTION
## 개요
회원탈퇴를 수행하는 API의 Swagger 문서가 올바르지 않은 내용을 포함하고 있던 것을 수정하였습니다

## 본문

사용자의 계정과 해당 계정의 원서를 삭제하는 API 문서에서, 기존에는 반환값 설명이 `원서 삭제 성공`으로 기재되어 있었습니다. 이를 보다 정확히 표현하기 위해 `회원탈퇴 및 해당하는 계정의 원서 삭제 성공`으로 수정하였습니다.
