### PR TITLE
[global] jpa의 open-in-view 옵션 비활성화

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -32,6 +32,7 @@ spring:
     properties:
       hibernate:
         format_sql: true
+    open-in-view: false
 
   data:
     redis:


### PR DESCRIPTION
## 개요

jpa의 open-in-view 옵션을 비활성화했습니다.

## 본문

`open-in-view` 옵션은 JPA의 영속성 컨텍스트를 언제까지 유지할지에 대한 옵션으로, 기본값은 true입니다.
이 옵션이 true일 경우, Client의 요청이 끝날 때까지  영속성 컨텍스트가 유지되고, 커넥션이 db에 반환되지 않습니다.
@Transactional이 적용된 메서드를 빠져나온후에도 유지되므로, Thymeleaf, jsp같이 직접 view를 백엔드에서 정의하는 경우가 아니라면 false로 두어 커넥션이 바로 반환되도록 하는것이 바람직하다고 생각됩니다.
따라서 application.yml에서 해당 옵션을 비활성화 하였습니다.

---

# RCA 룰

r: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)  
c: 웬만하면 반영해 주세요. (Comment)  
a: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)
