### PR TITLE
[oneseo] 원서 생성/수정 시 학번 필드 `Null` 허용

### DIFF
--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/dto/request/OneseoReqDto.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/dto/request/OneseoReqDto.java
@@ -86,7 +86,6 @@ public record OneseoReqDto(
 
         @Schema(description = "학생 번호", defaultValue = "30508")
         @Pattern(regexp = "^\\d{5}$")
-        @NotNull
         String studentNumber
 ) {
 }


### PR DESCRIPTION
## 개요
원서를 생성/수정 할 때 학번을 저장하는 필드에 `Null`이 바인딩 되는 것을 허용하도록 수정하였습니다
## 본문
지원전형이 검정고시일 경우 학번 정보를 입력받지 않기 때문에 해당 필드에 `Null`이 바인딩되는 것을 허용하도록 변경하였습니다.


---

# RCA 룰

r: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)  
c: 웬만하면 반영해 주세요. (Comment)  
a: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)
