### PR TITLE
[global] Monitoring을 위한 actuator, micrometer 설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -74,6 +74,9 @@ dependencies {
     /** actuator **/
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
 
+    /** micrometer **/
+    implementation 'io.micrometer:micrometer-registry-prometheus'
+
     /** logging **/
     implementation group: 'ca.pjer', name: 'logback-awslogs-appender', version: '1.6.0'
 

--- a/src/main/java/team/themoment/hellogsmv3/global/common/logging/LoggingFilter.java
+++ b/src/main/java/team/themoment/hellogsmv3/global/common/logging/LoggingFilter.java
@@ -23,7 +23,7 @@ public class LoggingFilter extends OncePerRequestFilter {
     private static final Logger log = LoggerFactory.getLogger(LoggingFilter.class);
 
     private static final String[] NOT_LOGGING_URL = {
-            "/api-docs/**", "/swagger-ui/**"
+            "/api-docs/**", "/swagger-ui/**", "/hello-management/prometheus/**"
     };
 
     private final AntPathMatcher matcher = new AntPathMatcher();

--- a/src/main/java/team/themoment/hellogsmv3/global/common/response/ApiResponseWrapper.java
+++ b/src/main/java/team/themoment/hellogsmv3/global/common/response/ApiResponseWrapper.java
@@ -19,6 +19,7 @@ public class ApiResponseWrapper implements ResponseBodyAdvice<Object> {
 
     private static final String[] NOT_WRAPPING_URL = {
             "/api-docs/**",
+            "/hello-management/prometheus/**"
     };
 
     private final AntPathMatcher matcher = new AntPathMatcher();

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -128,8 +128,11 @@ management:
   endpoints:
     web:
       exposure:
-        include: health
+        include: health,prometheus
       base-path: ${ACTUATOR_BASE_PATH}
+  endpoint:
+    prometheus:
+      enabled: true
 
 discord-alarm:
   url: ${DISCORD_RELAY_SERVER_URL}


### PR DESCRIPTION
## 개요

monitoring을 위해 actuator, micrometer를 설정하였습니다.

## 본문

micrometer-registry-prometheus를 추가하였고, actuator에서 prometheus 엔드포인트를 개방하였습니다.
추가로 CommonApiResponse Wrapping과 Logging 대상에서 prometheus 엔드포인트를 제외하였습니다.

# RCA 룰

r: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)  
c: 웬만하면 반영해 주세요. (Comment)  
a: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)
