### PR TITLE
[global] `Spring Boot`,`Spring Cloud` 버전 변경

### DIFF
--- a/DockerfileStage
+++ b/DockerfileStage
@@ -4,7 +4,7 @@ EXPOSE 8080
 
 WORKDIR /hellogsm-server-v3
 
-COPY build/libs/hellogsm-server-25-0.0.1-SNAPSHOT.jar hellogsm-stage-server.jar
+COPY build/libs/hellogsm-server-25-v20241011.0.jar hellogsm-stage-server.jar
 
 RUN ln -snf /usr/share/zoneinfo/Asia/Seoul /etc/localtime
 

--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ spotless {
 }
 
 group = 'team.themoment'
-version = '0.0.1-SNAPSHOT'
+version = 'v20241011.0'
 
 java {
 	sourceCompatibility = '17'

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
 	id 'java'
-	id 'org.springframework.boot' version '3.1.9'
+	id 'org.springframework.boot' version '3.5.6'
 	id 'io.spring.dependency-management' version '1.1.4'
 	id 'com.diffplug.spotless' version '6.25.0'
 }
@@ -103,7 +103,7 @@ dependencies {
 }
 
 ext {
-	set('springCloudVersion', "2022.0.3")
+	set('springCloudVersion', "2025.0.0")
 }
 
 dependencyManagement {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -71,10 +71,6 @@ spring:
             user-info-uri: https://kapi.kakao.com/v2/user/me
             authorization-uri: https://kauth.kakao.com/oauth/authorize
 
-  mvc:
-    throw-exception-if-no-handler-found: true
-    converters:
-      preferred-json-mapper: jackson
   web:
     resources:
       add-mappings: false
@@ -95,6 +91,9 @@ spring:
     multipart:
       max-file-size: 5MB
       max-request-size: 5MB
+  http:
+    converters:
+      preferred-json-mapper: jackson
 
 auth:
   allowed-origins:
@@ -132,7 +131,7 @@ management:
       base-path: ${ACTUATOR_BASE_PATH}
   endpoint:
     prometheus:
-      enabled: true
+      access: read_only
 
 discord-alarm:
   url: ${DISCORD_RELAY_SERVER_URL}


### PR DESCRIPTION
## 개요
Spring Session의 `creationTime key must not be null` 오류를 해결하기 위해 Spring Boot 버전을 업그레이드하였습니다.

## 본문

<img width="548" height="357" alt="image" src="https://github.com/user-attachments/assets/ee8174fd-478a-49cc-a913-723222e4ce0d" />

해당 이슈는 Spring Session 라이브러리의 알려진 문제로, 관련 이슈가 https://github.com/spring-projects/spring-session/issues/3347 및 https://github.com/spring-projects/spring-session/issues/2021 에 등록되어 있습니다.

이전에 #264, #263 PR을 통해 세션 정책을 강화하고 설정 로직을 방어적으로 수정하였으나, 근본적인 원인이 라이브러리 자체에 있어 완전한 해결이 어려웠습니다. 이에 따라 문제가 해결된 버전으로 업그레이드하는 방식을 채택하였습니다.

# RCA 룰

r: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)  
c: 웬만하면 반영해 주세요. (Comment)  
a: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)
