### PR TITLE
[global] 변경된 `Spring Boot` 버전에 맞도록 종속성 버전 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -87,7 +87,7 @@ dependencies {
 	implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
 
 	/** swagger **/
-	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.4.0'
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.13'
 
 	/** actuator **/
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'

--- a/build.gradle
+++ b/build.gradle
@@ -73,8 +73,8 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 
 	/** object serialize **/
-	implementation 'com.google.code.gson:gson:2.10.1'
-	implementation group: 'net.minidev', name: 'json-smart', version: '2.5.2'
+	implementation 'com.google.code.gson:gson:2.13.1'
+	implementation group: 'net.minidev', name: 'json-smart', version: '2.6.0'
 
 	/** aws **/
 	implementation 'io.awspring.cloud:spring-cloud-aws-starter-s3:3.4.0'

--- a/build.gradle
+++ b/build.gradle
@@ -77,8 +77,8 @@ dependencies {
 	implementation group: 'net.minidev', name: 'json-smart', version: '2.5.2'
 
 	/** aws **/
-	implementation 'io.awspring.cloud:spring-cloud-aws-starter-s3:3.0.1'
-	implementation 'io.awspring.cloud:spring-cloud-aws-starter-sns:3.0.1'
+	implementation 'io.awspring.cloud:spring-cloud-aws-starter-s3:3.4.0'
+	implementation 'io.awspring.cloud:spring-cloud-aws-starter-sns:3.4.0'
 
 	/** excel **/
 	implementation group: 'org.apache.poi', name: 'poi-ooxml', version: '5.4.1'


### PR DESCRIPTION
## 개요

`Spring Boot` 버전이 변경됨에 따라 호환되는 종속성들과 호환이 되지 않는 부분들이 발생하여 해당 하는 종속성들의 버전을 변경하였습니다.

## 본문
종속성 버전이 다음과 같이 변경되었습니다.

GSON
- `2.10.1` -> `2.13.1`

JSON-Smart
- `2.5.2` > `2.6.0`

Spring AWS Starter
- `3.0.1` -> `3.4.0`

Spring-Doc WebMVC UI
- `2.4.0` -> `2.8.13`

---

# RCA 룰

r: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)  
c: 웬만하면 반영해 주세요. (Comment)  
a: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)
