### PR TITLE
[auth] Kakao Feign 인터페이스 리팩터링

### DIFF
--- a/src/main/java/team/themoment/hellogsmv3/global/security/auth/service/provider/KakaoOAuthProvider.java
+++ b/src/main/java/team/themoment/hellogsmv3/global/security/auth/service/provider/KakaoOAuthProvider.java
@@ -1,5 +1,7 @@
 package team.themoment.hellogsmv3.global.security.auth.service.provider;
 
+import java.util.Map;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.security.oauth2.client.registration.ClientRegistration;
 import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
@@ -66,9 +68,11 @@ public class KakaoOAuthProvider implements OAuthProvider {
 
     private KakaoTokenResDto exchangeCodeForToken(String code, ClientRegistration clientRegistration) {
         try {
-            return kakaoOAuth2Client.exchangeCodeForToken(clientRegistration.getAuthorizationGrantType().getValue(),
-                    clientRegistration.getClientId(), clientRegistration.getClientSecret(), code,
+            Map<String, String> params = Map.of("grant_type", clientRegistration.getAuthorizationGrantType().getValue(),
+                    "client_id", clientRegistration.getClientId(), "client_secret",
+                    clientRegistration.getClientSecret(), "code", code, "redirect_uri",
                     clientRegistration.getRedirectUri());
+            return kakaoOAuth2Client.exchangeCodeForToken(params);
         } catch (Exception e) {
             throw new ExpectedException("Kakao OAuth 토큰 교환에 실패했습니다: " + e.getMessage(), HttpStatus.UNAUTHORIZED);
         }

--- a/src/main/java/team/themoment/hellogsmv3/global/thirdParty/feign/client/oauth/kakao/KakaoOAuth2Client.java
+++ b/src/main/java/team/themoment/hellogsmv3/global/thirdParty/feign/client/oauth/kakao/KakaoOAuth2Client.java
@@ -1,9 +1,11 @@
 package team.themoment.hellogsmv3.global.thirdParty.feign.client.oauth.kakao;
 
+import java.util.Map;
+
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RequestBody;
 
 import team.themoment.hellogsmv3.global.thirdParty.feign.client.dto.response.KakaoTokenResDto;
 import team.themoment.hellogsmv3.global.thirdParty.feign.config.FeignConfig;
@@ -12,7 +14,5 @@ import team.themoment.hellogsmv3.global.thirdParty.feign.config.FeignConfig;
 public interface KakaoOAuth2Client {
 
     @PostMapping(value = "/oauth/token", consumes = MediaType.APPLICATION_FORM_URLENCODED_VALUE)
-    KakaoTokenResDto exchangeCodeForToken(@RequestParam("grant_type") String grantType,
-            @RequestParam("client_id") String clientId, @RequestParam("client_secret") String clientSecret,
-            @RequestParam("code") String code, @RequestParam("redirect_uri") String redirectUri);
+    KakaoTokenResDto exchangeCodeForToken(@RequestBody Map<String, ?> formParams);
 }


### PR DESCRIPTION
## 개요

Google OAuth2 API 문제 해결 과정에서 수정된 구현 방식을 Kakao OAuth2에도 적용하여 OAuth2 클라이언트 구현을 통일합니다.

## 본문

### 배경
이전 작업에서 Google OAuth2 API의 `Content-Length` 헤더 요구사항으로 인한 411 에러를 해결하기 위해 GoogleOAuth2Client를 `@RequestBody Map` 방식으로 수정하였습니다. 그러나 KakaoOAuth2Client는 여전히 `@RequestParam` 방식을 사용하고 있어 구현 방식이 불일치하는 상황이었습니다.

### 문제 상황
- GoogleOAuth2Client는 `@RequestBody Map<String, ?>` 방식 사용
- KakaoOAuth2Client는 `@RequestParam` 방식 사용
- 동일한 OAuth2 토큰 교환 로직임에도 불구하고 구현 방식이 상이하여 일관성 부족

### 해결 방법
OAuth2 RFC 표준을 따르는 GoogleOAuth2Client의 방식을 KakaoOAuth2Client에도 적용하여 구현을 통일했습니다. POST body에 `application/x-www-form-urlencoded` 형식으로 파라미터를 전달하는 방식으로 통일했습니다.

### 변경 사항

**KakaoOAuth2Client.java**
- `@RequestParam` 방식에서 `@RequestBody Map<String, ?>` 방식으로 변경
- 메서드 시그니처를 GoogleOAuth2Client와 동일한 구조로 통일

**KakaoOAuthProvider.java**
- `exchangeCodeForToken` 메서드에서 `Map` 객체를 생성하여 파라미터 전달하도록 변경
- GoogleOAuthProvider와 동일한 패턴으로 통일

---

# RCA 룰

r: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)  
c: 웬만하면 반영해 주세요. (Comment)  
a: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)