### PR TITLE
[auth] 미사용 OAuth 관련 설정 Bean 주입 제거

### DIFF
--- a/src/main/java/team/themoment/hellogsmv3/global/security/SecurityConfig.java
+++ b/src/main/java/team/themoment/hellogsmv3/global/security/SecurityConfig.java
@@ -10,9 +10,6 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
-import org.springframework.security.oauth2.client.endpoint.DefaultAuthorizationCodeTokenResponseClient;
-import org.springframework.security.oauth2.client.endpoint.OAuth2AccessTokenResponseClient;
-import org.springframework.security.oauth2.client.endpoint.OAuth2AuthorizationCodeGrantRequest;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfiguration;
@@ -48,11 +45,6 @@ public class SecurityConfig {
                 .addFilter(HttpMethod.POST, "/oneseo/v3/oneseo/me", oneseoSubmissionStart, oneseoSubmissionEnd)
                 .addFilter(HttpMethod.PUT, "/oneseo/v3/oneseo/{memberId}", oneseoSubmissionStart, oneseoSubmissionEnd)
                 .addFilter(HttpMethod.POST, "/oneseo/v3/image", oneseoSubmissionStart, oneseoSubmissionEnd);
-    }
-
-    @Bean
-    public OAuth2AccessTokenResponseClient<OAuth2AuthorizationCodeGrantRequest> accessTokenResponseClient() {
-        return new DefaultAuthorizationCodeTokenResponseClient();
     }
 
     @Configuration


### PR DESCRIPTION
## 개요

`SecurityConfig` 클래스의 `DefaultAuthorizationCodeTokenResponseClient` 주입을 제거하였습니다.

## 본문

#243 에서 OAuth 인증 인가 방식이 변경됨에 따라 `SecurityConfig` 클래스에서 주입되던 아래 Bean이 아무런 효과가 없는 설정이 되었습니다.

```java
@Bean
public OAuth2AccessTokenResponseClient<OAuth2AuthorizationCodeGrantRequest> accessTokenResponseClient() {
    return new DefaultAuthorizationCodeTokenResponseClient();
}
```

`DefaultAuthorizationCodeTokenResponseClient`는 OAuth 2.0 Authorization Code Grant 방식에서 `Authorization Code`를 `Access Token`으로 교환하는 HTTP 요청을 처리하는 클라이언트입니다. 

구체적으로는 다음 작업을 수행합니다:
- OAuth 제공자의 Token Endpoint에 `Authorization Code`를 전송
- `client_id`, `client_secret`, `code`, `redirect_uri`, `grant_type` 등의 파라미터를 포함한 HTTP POST 요청 생성
- 응답을 파싱하여 Access Token과 Refresh Token을 획득

이 클라이언트는 Spring Security OAuth2 Login의 기본 필터 체인에서 자동으로 사용되며, OAuth 제공자와의 토큰 교환을 담당합니다.

#243에서 OAuth 인증 방식을 커스텀 구현으로 변경하면서 Spring Security의 기본 OAuth2 Login 필터 체인을 사용하지 않게 되었습니다. 따라서 이 Bean을 주입해도 실제로 호출되지 않으며, 설정상 아무런 효과가 없는 상태가 되었습니다.

이에 따라 해당 Bean을 제거하였습니다.


---

# RCA 룰

r: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)  
c: 웬만하면 반영해 주세요. (Comment)  
a: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)
