### PR TITLE
[global] 미사용 JSON 직렬화 종속성 제거

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -76,10 +76,6 @@ dependencies {
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 
-	/** object serialize **/
-	implementation 'com.google.code.gson:gson:2.13.1'
-	implementation group: 'net.minidev', name: 'json-smart', version: '2.6.0'
-
 	/** aws **/
 	implementation 'io.awspring.cloud:spring-cloud-aws-starter-s3:3.4.0'
 	implementation 'io.awspring.cloud:spring-cloud-aws-starter-sns:3.4.0'


### PR DESCRIPTION
## 개요

사용되는 부분이 없는 JSON 직렬화/역직렬화 종속성을 제거하여습니다.

## 본문

기존엔 중학교 성적 저장과 같은 부분에서 `GSON`,`Smart-JSON` 종속성을 사용하였기에 해당 종속성이 서버 애플리케이션에 포함되었지만 2025년 운영기간에선 `Jackson`만 사용하고 있기 때문에 불필요한 종속성이 된 2가지 종속성을 완전히 제거하였습니다.

---

# RCA 룰

r: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)  
c: 웬만하면 반영해 주세요. (Comment)  
a: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)
