### PR TITLE
[oneseo] 명시적인 트랜잭션 범위 설정을 통한 LazyInitializationException 방지

### DIFF
--- a/src/main/java/team/themoment/hellogsmv3/domain/member/service/QueryMyFirstTestResultService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/member/service/QueryMyFirstTestResultService.java
@@ -1,6 +1,7 @@
 package team.themoment.hellogsmv3.domain.member.service;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
 import team.themoment.hellogsmv3.domain.member.dto.response.FoundMemberFirstTestResDto;
@@ -16,6 +17,7 @@ public class QueryMyFirstTestResultService {
     private final MemberService memberService;
     private final OneseoService oneseoService;
 
+    @Transactional(readOnly = true)
     public FoundMemberFirstTestResDto execute(Long memberId) {
         Member member = memberService.findByIdOrThrow(memberId);
         Oneseo oneseo = oneseoService.findByMemberOrThrow(member);

--- a/src/main/java/team/themoment/hellogsmv3/domain/member/service/QueryMySecondTestResultService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/member/service/QueryMySecondTestResultService.java
@@ -1,6 +1,7 @@
 package team.themoment.hellogsmv3.domain.member.service;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
 import team.themoment.hellogsmv3.domain.member.dto.response.FoundMemberSecondTestResDto;
@@ -16,6 +17,7 @@ public class QueryMySecondTestResultService {
     private final MemberService memberService;
     private final OneseoService oneseoService;
 
+    @Transactional(readOnly = true)
     public FoundMemberSecondTestResDto execute(Long memberId) {
         Member member = memberService.findByIdOrThrow(memberId);
         Oneseo oneseo = oneseoService.findByMemberOrThrow(member);

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyCompetencyEvaluationScoreService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyCompetencyEvaluationScoreService.java
@@ -3,6 +3,7 @@ package team.themoment.hellogsmv3.domain.oneseo.service;
 import java.math.BigDecimal;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
 import team.themoment.hellogsmv3.domain.member.entity.Member;
@@ -20,6 +21,7 @@ public class ModifyCompetencyEvaluationScoreService {
     private final OneseoService oneseoService;
     private final EntranceTestResultRepository entranceTestResultRepository;
 
+    @Transactional
     public void execute(Long memberId, CompetencyEvaluationScoreReqDto competencyEvaluationScoreReqDto) {
         Member member = memberService.findByIdOrThrow(memberId);
         Oneseo oneseo = oneseoService.findByMemberOrThrow(member);

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/QueryOneseoByIdService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/QueryOneseoByIdService.java
@@ -6,6 +6,7 @@ import java.util.List;
 
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
 import team.themoment.hellogsmv3.domain.member.entity.Member;
@@ -27,6 +28,7 @@ public class QueryOneseoByIdService {
     private final OneseoService oneseoService;
 
     @Cacheable(value = ONESEO_CACHE_VALUE, key = "#memberId")
+    @Transactional(readOnly = true)
     public FoundOneseoResDto execute(Long memberId) {
         Member member = memberService.findByIdOrThrow(memberId);
         Oneseo oneseo = oneseoService.findByMemberOrThrow(member);


### PR DESCRIPTION
## 개요

명시적인 트랜잭션 범위 설정을 통해 LazyInitializationException을 방지했습니다.

## 본문

#283 PR에서 jpa open in view 옵션을 비활성화 하여 트랜잭션 범위 밖에서 lazy loading 시도시 예외가 발생합니다.
`findByMember`를 사용하던 일부 서비스 코드 내에서 @Transactional 없이 lazy loading을 시도했고, 문제가 발생하였습니다.
서비스 코드에 @Transactional을 추가하여 임시로 문제를 해결하였고,
추후에 fetchJoin을 사용해서 lazy loading을 없애는 것으로 결정되었습니다.

# RCA 룰

r: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)  
c: 웬만하면 반영해 주세요. (Comment)  
a: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)
