### PR TITLE
[oneseo] 엑셀 시트 출력 시 `IOT`를 `IoT`로 표현하도록 수정

### DIFF
--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/DownloadExcelService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/DownloadExcelService.java
@@ -25,6 +25,7 @@ import lombok.RequiredArgsConstructor;
 import team.themoment.hellogsmv3.domain.oneseo.entity.EntranceTestResult;
 import team.themoment.hellogsmv3.domain.oneseo.entity.Oneseo;
 import team.themoment.hellogsmv3.domain.oneseo.entity.OneseoPrivacyDetail;
+import team.themoment.hellogsmv3.domain.oneseo.entity.type.Major;
 import team.themoment.hellogsmv3.domain.oneseo.entity.type.Screening;
 import team.themoment.hellogsmv3.domain.oneseo.entity.type.YesNo;
 import team.themoment.hellogsmv3.domain.oneseo.repository.OneseoRepository;
@@ -167,9 +168,9 @@ public class DownloadExcelService {
 
         BigDecimal finalScore = calculateFinalScore(entranceTestResult);
 
-        String firstDesiredMajor = safeToString(oneseo.getDesiredMajors().getFirstDesiredMajor());
-        String secondDesiredMajor = safeToString(oneseo.getDesiredMajors().getSecondDesiredMajor());
-        String thirdDesiredMajor = safeToString(oneseo.getDesiredMajors().getThirdDesiredMajor());
+        String firstDesiredMajor = convertMajorDisplayName(oneseo.getDesiredMajors().getFirstDesiredMajor());
+        String secondDesiredMajor = convertMajorDisplayName(oneseo.getDesiredMajors().getSecondDesiredMajor());
+        String thirdDesiredMajor = convertMajorDisplayName(oneseo.getDesiredMajors().getThirdDesiredMajor());
 
         return List.of(String.valueOf(index), safeToString(oneseo.getOneseoSubmitCode()),
                 safeToString(oneseo.getExaminationNumber()), safeToString(oneseo.getMember().getName()),
@@ -196,6 +197,12 @@ public class DownloadExcelService {
 
     private String safeToString(Object obj) {
         return obj != null ? obj.toString() : "";
+    }
+
+    private String convertMajorDisplayName(Major major) {
+        if (major == null)
+            return "";
+        return major == Major.IOT ? "IoT" : major.toString();
     }
 
     private String formatBirth(LocalDate birth) {

--- a/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/DownloadExcelServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/DownloadExcelServiceTest.java
@@ -164,7 +164,7 @@ public class DownloadExcelServiceTest {
             assertEquals(oneseo.getMember().getName(), dataRow.getCell(3).getStringCellValue());
             assertEquals("AI", dataRow.getCell(4).getStringCellValue());
             assertEquals("SW", dataRow.getCell(5).getStringCellValue());
-            assertEquals("IOT", dataRow.getCell(6).getStringCellValue());
+            assertEquals("IoT", dataRow.getCell(6).getStringCellValue());
             assertEquals("20240731", dataRow.getCell(7).getStringCellValue());
             assertEquals("남자", dataRow.getCell(8).getStringCellValue());
             assertEquals("광주광역시 광산구 송정동 상무대로 312 동행관", dataRow.getCell(9).getStringCellValue());


### PR DESCRIPTION
## 개요

[해당 요구사항](https://discord.com/channels/942787694872899604/1163324601577771008/1422755306697523210)을 반영하였습니다.

## 본문

`IOT`로 표현되던 `1지망`,`2지망`,`3지망` 셸의 값을 `IoT`로 변경해달라는 요청에 따라 `DownloadExcelService`를 수정하였습니다. `Major` Enum을 수정하는 방안도 검토 되었으나 Excel에서만 수정되는 것으로 수정 사항이 한정적인 것을 고려하여 해당 서비스에서 포맷팅 메서드를 통하도록 결정하였습니다.

---

# RCA 룰

r: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)  
c: 웬만하면 반영해 주세요. (Comment)  
a: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)
