### PR TITLE
[global] QueryDSL 종속성 변경

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ spotless {
 }
 
 group = 'team.themoment'
-version = 'v20241011.0'
+version = 'v20251103.0'
 
 java {
 	sourceCompatibility = '17'

--- a/build.gradle
+++ b/build.gradle
@@ -60,10 +60,10 @@ dependencies {
 	runtimeOnly 'com.mysql:mysql-connector-j'
 
 	/** queryDsl **/
-	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
-	annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
-	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
-	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+	implementation 'io.github.openfeign.querydsl:querydsl-jpa:7.0'
+	annotationProcessor 'io.github.openfeign.querydsl:querydsl-apt:7.0:jakarta'
+	annotationProcessor 'jakarta.annotation:jakarta.annotation-api'
+	annotationProcessor 'jakarta.persistence:jakarta.persistence-api'
 
 	/** test **/
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'


### PR DESCRIPTION
## 개요

지원종료된 공식 [QueryDSL](https://github.com/querydsl/querydsl) 대신 포크되어 계속 유지보수가 진행되고 있는 OpenFeign 산하의 [QueryDSL](https://github.com/OpenFeign/querydsl)로 종속성을 변경하였습니다.

## 본문

기존 지원 종료된 공식 QueryDSL에서는 CVE-2024-49203 보안 취약점과 더불어 지원이 종료되었다는 문제가 있었습니다.다만 OpenFeign에서 해당 프로젝트를 포크하여 운영하는 기능상으로 완전히 동일한 오픈소스 프로젝트가 있어 해당 프로젝트로 종속성을 변경하였습니다.

또한 #332 PR로 프로덕션의 버전이 변경되었지만 Gradle 패키지 버전은 변경되지 않았던 것을 수정하였습니다.

---

# RCA 룰

r: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)  
c: 웬만하면 반영해 주세요. (Comment)  
a: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)
