### PR TITLE
[global] 클라우드 다이어그램과 실제 인프라 구성이 일치하도록 수정

### DIFF
--- a/cloud-diagram.py
+++ b/cloud-diagram.py
@@ -65,7 +65,8 @@ with Diagram("HelloGSM-2025 Cloud Architecture",
                 prod_bastion_nat = EC2("Bastion + NAT\nInstance")
 
             with Cluster("Private", graph_attr={"bgcolor": "#ffcdd2", "style": "rounded", "margin": "8"}):
-                prod_app = EC2("Spring Boot\n+ Redis")
+                prod_app = EC2("Spring Boot")
+                prod_redis = EC2("Redis")
                 prod_db = RDS("MySQL")
 
         with Cluster("Stage", graph_attr={"bgcolor": "#e3f2fd", "style": "rounded", "margin": "10"}):
@@ -73,7 +74,7 @@ with Diagram("HelloGSM-2025 Cloud Architecture",
                 dev_bastion_nat = EC2("Bastion + NAT\nInstance")
 
             with Cluster("Private", graph_attr={"bgcolor": "#ffcdd2", "style": "rounded", "margin": "8"}):
-                dev_app = EC2("All-in-One")
+                dev_app = EC2("Spring Boot\n+ Redis\n+ MySQL")
 
     user >> Edge(label="https", color="#4caf50") >> internet_gateway
     internet_gateway >> Edge(color="#4caf50") >> alb
@@ -81,6 +82,7 @@ with Diagram("HelloGSM-2025 Cloud Architecture",
     alb >> Edge(label="prod", color="#2196f3") >> prod_app
     alb >> Edge(label="stage", color="#03a9f4") >> dev_app
 
+    prod_app >> Edge(label="cache", color="#e91e63") >> prod_redis
     prod_app >> Edge(label="db", color="#4caf50") >> prod_db
 
     codedeploy >> Edge(label="deploy", color="#ff5722") >> prod_app
@@ -90,6 +92,7 @@ with Diagram("HelloGSM-2025 Cloud Architecture",
     dev_app >> Edge(label="out", color="#795548") >> dev_bastion_nat
 
     prod_bastion_nat >> Edge(label="ssh", color="#9c27b0") >> prod_app
+    prod_bastion_nat >> Edge(label="ssh", color="#9c27b0") >> prod_redis
     prod_bastion_nat >> Edge(label="db", color="#9c27b0") >> prod_db
     dev_bastion_nat >> Edge(label="ssh", color="#9c27b0") >> dev_app
 


### PR DESCRIPTION
## 개요

클라우드 다이어그램에서 실제 인프라 구성과 다르게 표현된 부분을 수정하였습니다.

## 본문

클라우드 다이어그램의 프로덕션 환경 부분에 Redis와 서버 애플리케이션이 같은 인스턴스에서 구동되는 것처럼 표현되었던 것을 명확하게 분리하도록 변경하였습니다.

<img width="1546" height="2011" alt="hellogsm-2025_cloud_architecture" src="https://github.com/user-attachments/assets/3b873a4b-81eb-44e3-aea4-e55041f6e68c" />


---

# RCA 룰

r: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)  
c: 웬만하면 반영해 주세요. (Comment)  
a: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)
