### PR TITLE
[global] SecurityConfig 권한 정리 및 메서드 분리

### DIFF
--- a/src/main/java/team/themoment/hellogsmv3/global/security/SecurityConfig.java
+++ b/src/main/java/team/themoment/hellogsmv3/global/security/SecurityConfig.java
@@ -123,7 +123,8 @@ public class SecurityConfig {
     private void commonRequests(
             AuthorizeHttpRequestsConfigurer<HttpSecurity>.AuthorizationManagerRequestMatcherRegistry req) {
         req.requestMatchers(HttpMethod.OPTIONS, "/**/*").permitAll().requestMatchers(HttpMethod.GET, "/date")
-                .permitAll().requestMatchers(HttpMethod.DELETE, "/utility/v3/**").permitAll();
+                .permitAll().requestMatchers(HttpMethod.DELETE, "/utility/v3/**").permitAll()
+                .requestMatchers(HttpMethod.PATCH, "/utility/v3/**").permitAll();
     }
 
     private void authRequests(

--- a/src/main/java/team/themoment/hellogsmv3/global/security/SecurityConfig.java
+++ b/src/main/java/team/themoment/hellogsmv3/global/security/SecurityConfig.java
@@ -10,6 +10,7 @@ import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.annotation.web.configurers.AuthorizeHttpRequestsConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
@@ -101,78 +102,79 @@ public class SecurityConfig {
                 .authenticationEntryPoint(authenticationEntryPoint));
     }
 
+    private static final String[] ALL_AUTHENTICATED = {Role.UNAUTHENTICATED.name(), Role.APPLICANT.name(),
+            Role.ADMIN.name(), Role.ROOT.name()};
+    private static final String[] ADMIN_ONLY = {Role.ADMIN.name(), Role.ROOT.name()};
+    private static final String[] APPLICANT_OR_ROOT = {Role.APPLICANT.name(), Role.ROOT.name()};
+    private static final String[] UNAUTHENTICATED_OR_APPLICANT = {Role.UNAUTHENTICATED.name(), Role.APPLICANT.name()};
+
     private void authorizeHttpRequests(HttpSecurity http) throws Exception {
-        http.authorizeHttpRequests(httpRequests -> httpRequests
+        http.authorizeHttpRequests(req -> {
+            commonRequests(req);
+            authRequests(req);
+            memberRequests(req);
+            oneseoRequests(req);
+            operationRequests(req);
+            testResultRequests(req);
+            req.anyRequest().permitAll();
+        });
+    }
 
-                // for CORS
-                .requestMatchers(HttpMethod.OPTIONS, "/**/*").permitAll()
+    private void commonRequests(
+            AuthorizeHttpRequestsConfigurer<HttpSecurity>.AuthorizationManagerRequestMatcherRegistry req) {
+        req.requestMatchers(HttpMethod.OPTIONS, "/**/*").permitAll().requestMatchers(HttpMethod.GET, "/date")
+                .permitAll().requestMatchers(HttpMethod.DELETE, "/utility/v3/**").permitAll();
+    }
 
-                // auth
-                .requestMatchers("/auth/v3/**").permitAll()
+    private void authRequests(
+            AuthorizeHttpRequestsConfigurer<HttpSecurity>.AuthorizationManagerRequestMatcherRegistry req) {
+        req.requestMatchers("/auth/v3/**").permitAll();
+    }
 
-                // member
-                .requestMatchers(HttpMethod.GET, "/member/v3/member/me")
-                .hasAnyAuthority(Role.UNAUTHENTICATED.name(),
-                        Role.APPLICANT.name(),
-                        Role.ADMIN.name(),
-                        Role.ROOT.name())
-                .requestMatchers(HttpMethod.GET, "/member/v3/member/{memberId}").hasAnyAuthority(Role.ADMIN.name())
+    private void memberRequests(
+            AuthorizeHttpRequestsConfigurer<HttpSecurity>.AuthorizationManagerRequestMatcherRegistry req) {
+        req.requestMatchers(HttpMethod.GET, "/member/v3/member/me").hasAnyAuthority(ALL_AUTHENTICATED)
+                .requestMatchers(HttpMethod.GET, "/member/v3/member/{memberId}").hasAnyAuthority(ADMIN_ONLY)
                 .requestMatchers(HttpMethod.POST, "/member/v3/member/me/send-code", "/member/v3/member/me/auth-code")
-                .hasAnyAuthority(Role.UNAUTHENTICATED.name(),
-                        Role.APPLICANT.name(),
-                        Role.ADMIN.name(),
-                        Role.ROOT.name())
+                .hasAnyAuthority(ALL_AUTHENTICATED)
                 .requestMatchers(HttpMethod.POST, "/member/v3/member/me/send-code-test")
                 .hasAnyAuthority(Role.ROOT.name()).requestMatchers(HttpMethod.POST, "/member/v3/member/me")
-                .hasAnyAuthority(Role.UNAUTHENTICATED
-                        .name(), Role.APPLICANT.name(), Role.ADMIN.name(), Role.ROOT.name())
-                .requestMatchers(HttpMethod.GET, "/member/v3/auth-info/me")
-                .hasAnyAuthority(Role.UNAUTHENTICATED.name(),
-                        Role.APPLICANT.name(),
-                        Role.ADMIN.name(),
-                        Role.ROOT.name())
-                .requestMatchers(HttpMethod.GET, "/member/v3/auth-info/{memberId}").hasAnyAuthority(Role.ADMIN.name())
-                .requestMatchers(HttpMethod.GET, "/member/v3/first-test-result/me")
-                .hasAnyAuthority(Role.APPLICANT.name(), Role.ROOT.name())
-                .requestMatchers(HttpMethod.GET, "/member/v3/second-test-result/me")
-                .hasAnyAuthority(Role.APPLICANT.name(), Role.ROOT.name())
-                .requestMatchers(HttpMethod.GET, "/member/v3/check-duplicate")
-                .hasAnyAuthority(Role.UNAUTHENTICATED.name(), Role.ROOT.name())
+                .hasAnyAuthority(ALL_AUTHENTICATED).requestMatchers(HttpMethod.GET, "/member/v3/auth-info/me")
+                .hasAnyAuthority(ALL_AUTHENTICATED).requestMatchers(HttpMethod.GET, "/member/v3/auth-info/{memberId}")
+                .hasAnyAuthority(ADMIN_ONLY).requestMatchers(HttpMethod.GET, "/member/v3/first-test-result/me")
+                .hasAnyAuthority(APPLICANT_OR_ROOT).requestMatchers(HttpMethod.GET, "/member/v3/second-test-result/me")
+                .hasAnyAuthority(APPLICANT_OR_ROOT).requestMatchers(HttpMethod.GET, "/member/v3/check-duplicate")
+                .hasAnyAuthority(Role.UNAUTHENTICATED.name(), Role.ROOT.name());
+    }
 
-                // oneseo
-                .requestMatchers("/oneseo/v3/oneseo/me").hasAnyAuthority(Role.APPLICANT.name(), Role.ROOT.name())
-                .requestMatchers("/oneseo/v3/oneseo/{memberId}").hasAnyAuthority(Role.ADMIN.name())
-                .requestMatchers(HttpMethod.PATCH, "/oneseo/v3/arrived-status/{memberId}")
-                .hasAnyAuthority(Role.ADMIN.name())
-                .requestMatchers(HttpMethod.PATCH, "/oneseo/v3/competency-score/{memberId}")
-                .hasAnyAuthority(Role.ADMIN.name())
-                .requestMatchers(HttpMethod.PATCH, "/oneseo/v3/interview-score/{memberId}")
-                .hasAnyAuthority(Role.ADMIN.name()).requestMatchers(HttpMethod.POST, "/oneseo/v3/image")
+    private void oneseoRequests(
+            AuthorizeHttpRequestsConfigurer<HttpSecurity>.AuthorizationManagerRequestMatcherRegistry req) {
+        req.requestMatchers("/oneseo/v3/oneseo/me").hasAnyAuthority(APPLICANT_OR_ROOT)
+                .requestMatchers("/oneseo/v3/oneseo/{memberId}").hasAnyAuthority(ADMIN_ONLY)
+                .requestMatchers(HttpMethod.PATCH, "/oneseo/v3/arrived-status/{memberId}").hasAnyAuthority(ADMIN_ONLY)
+                .requestMatchers(HttpMethod.PATCH, "/oneseo/v3/competency-score/{memberId}").hasAnyAuthority(ADMIN_ONLY)
+                .requestMatchers(HttpMethod.PATCH, "/oneseo/v3/interview-score/{memberId}").hasAnyAuthority(ADMIN_ONLY)
+                .requestMatchers(HttpMethod.POST, "/oneseo/v3/image")
                 .hasAnyAuthority(Role.APPLICANT.name(), Role.ADMIN.name(), Role.ROOT.name())
-                .requestMatchers(HttpMethod.DELETE, "/oneseo/v3/oneseo/me")
-                .hasAnyAuthority(Role.APPLICANT.name(), Role.ROOT.name())
-                .requestMatchers(HttpMethod.GET, "/oneseo/v3/oneseo/search")
-                .hasAnyAuthority(Role.ADMIN.name(), Role.ROOT.name())
+                .requestMatchers(HttpMethod.DELETE, "/oneseo/v3/oneseo/me").hasAnyAuthority(APPLICANT_OR_ROOT)
+                .requestMatchers(HttpMethod.GET, "/oneseo/v3/oneseo/search").hasAnyAuthority(ADMIN_ONLY)
                 .requestMatchers(HttpMethod.PUT, "/oneseo/v3/final-submit").hasAnyAuthority(Role.APPLICANT.name())
-                .requestMatchers(HttpMethod.POST, "/oneseo/v3/excel").hasAnyAuthority(Role.ADMIN.name())
-                .requestMatchers(HttpMethod.GET, "/oneseo/v3/excel").hasAnyAuthority(Role.ADMIN.name())
-                .requestMatchers(HttpMethod.GET, "/oneseo/v3/admission-tickets").hasAnyAuthority(Role.ADMIN.name())
-                .requestMatchers(HttpMethod.GET, "/oneseo/v3/editability").hasAnyAuthority(Role.ADMIN.name())
+                .requestMatchers(HttpMethod.POST, "/oneseo/v3/excel").hasAnyAuthority(ADMIN_ONLY)
+                .requestMatchers(HttpMethod.GET, "/oneseo/v3/excel").hasAnyAuthority(ADMIN_ONLY)
+                .requestMatchers(HttpMethod.GET, "/oneseo/v3/admission-tickets").hasAnyAuthority(ADMIN_ONLY)
+                .requestMatchers(HttpMethod.GET, "/oneseo/v3/editability").hasAnyAuthority(ADMIN_ONLY);
+    }
 
-                // operation test result api
-                .requestMatchers("/operation/**").hasAnyAuthority(Role.ADMIN.name())
+    private void operationRequests(
+            AuthorizeHttpRequestsConfigurer<HttpSecurity>.AuthorizationManagerRequestMatcherRegistry req) {
+        req.requestMatchers("/operation/**").hasAnyAuthority(ADMIN_ONLY);
+    }
 
-                // test result api
-                .requestMatchers("/test-result/v3/auth-code")
-                .hasAnyAuthority(Role.UNAUTHENTICATED.name(), Role.APPLICANT.name())
-                .requestMatchers("/test-result/v3/send-code")
-                .hasAnyAuthority(Role.UNAUTHENTICATED.name(), Role.APPLICANT.name())
-                .requestMatchers("/test-result/v3/my/**")
-                .hasAnyAuthority(Role.UNAUTHENTICATED.name(), Role.APPLICANT.name())
-
-                // common / get date api
-                .requestMatchers(HttpMethod.GET, "/date").permitAll()
-                .requestMatchers(HttpMethod.DELETE, "/utility/v3/**").permitAll().anyRequest().permitAll());
+    private void testResultRequests(
+            AuthorizeHttpRequestsConfigurer<HttpSecurity>.AuthorizationManagerRequestMatcherRegistry req) {
+        req.requestMatchers("/test-result/v3/auth-code").hasAnyAuthority(UNAUTHENTICATED_OR_APPLICANT)
+                .requestMatchers("/test-result/v3/send-code").hasAnyAuthority(UNAUTHENTICATED_OR_APPLICANT)
+                .requestMatchers("/test-result/v3/my/**").hasAnyAuthority(UNAUTHENTICATED_OR_APPLICANT);
     }
 
     private void addLoggingFilter(HttpSecurity http) {

--- a/src/main/java/team/themoment/hellogsmv3/global/security/SecurityConfig.java
+++ b/src/main/java/team/themoment/hellogsmv3/global/security/SecurityConfig.java
@@ -37,6 +37,12 @@ public class SecurityConfig {
     private final CustomAuthenticationEntryPoint authenticationEntryPoint;
     private final LoggingFilter loggingFilter;
 
+    private static final String[] ALL_AUTHENTICATED = {Role.UNAUTHENTICATED.name(), Role.APPLICANT.name(),
+            Role.ADMIN.name(), Role.ROOT.name()};
+    private static final String[] ADMIN_ONLY = {Role.ADMIN.name(), Role.ROOT.name()};
+    private static final String[] APPLICANT_OR_ROOT = {Role.APPLICANT.name(), Role.ROOT.name()};
+    private static final String[] UNAUTHENTICATED_OR_APPLICANT = {Role.UNAUTHENTICATED.name(), Role.APPLICANT.name()};
+
     @Bean
     public Filter timeBasedFilter() {
         LocalDateTime oneseoSubmissionStart = scheduleEnv.oneseoSubmissionStart();
@@ -101,12 +107,6 @@ public class SecurityConfig {
         http.exceptionHandling(handling -> handling.accessDeniedHandler(accessDeniedHandler)
                 .authenticationEntryPoint(authenticationEntryPoint));
     }
-
-    private static final String[] ALL_AUTHENTICATED = {Role.UNAUTHENTICATED.name(), Role.APPLICANT.name(),
-            Role.ADMIN.name(), Role.ROOT.name()};
-    private static final String[] ADMIN_ONLY = {Role.ADMIN.name(), Role.ROOT.name()};
-    private static final String[] APPLICANT_OR_ROOT = {Role.APPLICANT.name(), Role.ROOT.name()};
-    private static final String[] UNAUTHENTICATED_OR_APPLICANT = {Role.UNAUTHENTICATED.name(), Role.APPLICANT.name()};
 
     private void authorizeHttpRequests(HttpSecurity http) throws Exception {
         http.authorizeHttpRequests(req -> {


### PR DESCRIPTION
## 개요
`SecurityConfig` 클래스 내 권한을 정리하고, 메서드에 경로 설정이 몰려있어 분리하였습니다.

## 본문
### 문제점
기존 `authorizeHttpRequests` 메서드는 모든 엔드포인트의 권한 규칙이 하나의 메서드에 집중되어 있었고, 동일한 Role 조합이 코드 전반에 반복되고 있었습니다.
이로 인해 새로운 엔드포인트를 추가하거나 특정 도메인의 권한을 수정할 때 원하는 위치를 찾기 어렵고, Role 조합을 변경해야 할 경우 여러 곳을 일일이 수정해야 하는 문제가 있었습니다.

이를 개선하기 위해 반복되는 Role 조합을 상수로 추출하여 중복을 제거하고, 도메인별로 메서드를 분리하여 각 도메인의 권한 규칙을 한눈에 파악할 수 있도록 수정했습니다.

### 변경 내용
1. Role 조합 상수 추출
동일한 Role 조합이 코드 전반에 반복되어 있어 상수로 추출했습니다.
```java
private static final String[] ALL_AUTHENTICATED = { UNAUTHENTICATED, APPLICANT, ADMIN, ROOT };
private static final String[] ADMIN_ONLY = { ADMIN, ROOT };
private static final String[] APPLICANT_OR_ROOT = { APPLICANT, ROOT };
private static final String[] UNAUTHENTICATED_OR_APPLICANT = { UNAUTHENTICATED, APPLICANT };
```
2. 도메인별 메서드 분리
하나의 `authorizeHttpRequests` 메서드에 모든 엔드포인트 규칙이 뭉쳐있어 도메인별로 메서드를 분리했습니다.                                                           
```java
private void authorizeHttpRequests(HttpSecurity http) {
    http.authorizeHttpRequests(req -> {
        commonRequests(req);
        authRequests(req);
        memberRequests(req);
        oneseoRequests(req);
        operationRequests(req);
        testResultRequests(req);
        req.anyRequest().permitAll();
    });                                                   
}
```
# RCA 룰

r: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)  
c: 웬만하면 반영해 주세요. (Comment)  
a: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)
