### PR TITLE
[global] Docker 빌드 시 사용되는 JDK 버전이 올바르지 않았던 문제 수정

### DIFF
--- a/DockerfileProd
+++ b/DockerfileProd
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:17-jre
+FROM eclipse-temurin:25-jre
 
 EXPOSE 8080
 

--- a/DockerfileStage
+++ b/DockerfileStage
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:17-jre
+FROM eclipse-temurin:25-jre
 
 EXPOSE 8080
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,8 +1,8 @@
 plugins {
 	id 'java'
-	id 'org.springframework.boot' version '4.0.3'
+	id 'org.springframework.boot' version '4.0.5'
 	id 'io.spring.dependency-management' version '1.1.7'
-	id 'com.diffplug.spotless' version '8.2.1'
+	id 'com.diffplug.spotless' version '8.4.0'
 }
 
 
@@ -97,7 +97,7 @@ dependencies {
 	implementation 'io.micrometer:micrometer-registry-prometheus'
 
 	/** logging **/
-	implementation platform('software.amazon.awssdk:bom:2.42.3')
+	implementation platform('software.amazon.awssdk:bom:2.42.30')
 	implementation 'software.amazon.awssdk:cloudwatchlogs'
 
 	/** open feign **/

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
## 개요

일부 노후화된 종속성 설정을 변경하고 배포 시 사용하는 JDK 버전을 변경하였습니다.

## 본문
JDK 버전이 Gradle 스크립트에 명시된 버전과 일치하지 않았던 것을 수정하여 배포 환경에서 작동을 보장하였고 노후화된 일부 종속성을 버전 변경하였습니다.
### 변경 

`Spring Boot` 버전 `4.0.3` -> `4.0.5`
`Spotless` 버전 `8.2.1` -> `8.4.0`
`AWS SDK BOM` 버전 `2.42.3` -> `2.42.30`
Docker 이미지 빌드 시 사용하는 JDK 버전 변경 `17` -> `25`

---

# RCA 룰

r: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)  
c: 웬만하면 반영해 주세요. (Comment)  
a: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)
