### PR TITLE
[global] Redis 캐시 역직렬화 오류 수정

### DIFF
--- a/src/main/java/team/themoment/hellogsmv3/global/config/RedisCacheConfig.java
+++ b/src/main/java/team/themoment/hellogsmv3/global/config/RedisCacheConfig.java
@@ -31,7 +31,6 @@ public class RedisCacheConfig {
                         .fromSerializer(GenericJacksonJsonRedisSerializer.builder().build()))
                 .entryTtl(Duration.ofDays(4L));
 
-        // oneseo 캐시에만 타입 정보를 포함하며, 허용 타입을 프로젝트 패키지로 제한
         RedisCacheConfiguration oneseoConfig = defaultConfig
                 .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(
                         GenericJacksonJsonRedisSerializer.builder().enableDefaultTyping(BasicPolymorphicTypeValidator

--- a/src/main/java/team/themoment/hellogsmv3/global/config/RedisCacheConfig.java
+++ b/src/main/java/team/themoment/hellogsmv3/global/config/RedisCacheConfig.java
@@ -1,6 +1,9 @@
 package team.themoment.hellogsmv3.global.config;
 
+import static team.themoment.hellogsmv3.domain.oneseo.service.OneseoService.ONESEO_CACHE_VALUE;
+
 import java.time.Duration;
+import java.util.Map;
 
 import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.EnableCaching;
@@ -21,18 +24,20 @@ public class RedisCacheConfig {
 
     @Bean
     public CacheManager contentCacheManager(RedisConnectionFactory cf) {
-        RedisCacheConfiguration redisCacheConfiguration = RedisCacheConfiguration.defaultCacheConfig()
+        RedisCacheConfiguration defaultConfig = RedisCacheConfiguration.defaultCacheConfig()
                 .serializeKeysWith(
                         RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()))
-                .serializeValuesWith(
-                        RedisSerializationContext.SerializationPair
-                                .fromSerializer(GenericJacksonJsonRedisSerializer.builder()
-                                        .enableDefaultTyping(BasicPolymorphicTypeValidator.builder()
-                                                .allowIfBaseType(Object.class).build())
-                                        .build()))
+                .serializeValuesWith(RedisSerializationContext.SerializationPair
+                        .fromSerializer(GenericJacksonJsonRedisSerializer.builder().build()))
                 .entryTtl(Duration.ofDays(4L));
 
-        return RedisCacheManager.RedisCacheManagerBuilder.fromConnectionFactory(cf)
-                .cacheDefaults(redisCacheConfiguration).build();
+        // oneseo 캐시에만 타입 정보를 포함하며, 허용 타입을 프로젝트 패키지로 제한
+        RedisCacheConfiguration oneseoConfig = defaultConfig
+                .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(
+                        GenericJacksonJsonRedisSerializer.builder().enableDefaultTyping(BasicPolymorphicTypeValidator
+                                .builder().allowIfSubType("team.themoment.hellogsmv3").build()).build()));
+
+        return RedisCacheManager.RedisCacheManagerBuilder.fromConnectionFactory(cf).cacheDefaults(defaultConfig)
+                .withInitialCacheConfigurations(Map.of(ONESEO_CACHE_VALUE, oneseoConfig)).build();
     }
 }

--- a/src/main/java/team/themoment/hellogsmv3/global/config/RedisCacheConfig.java
+++ b/src/main/java/team/themoment/hellogsmv3/global/config/RedisCacheConfig.java
@@ -13,6 +13,8 @@ import org.springframework.data.redis.serializer.GenericJacksonJsonRedisSerializ
 import org.springframework.data.redis.serializer.RedisSerializationContext;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
+import tools.jackson.databind.jsontype.BasicPolymorphicTypeValidator;
+
 @Configuration
 @EnableCaching
 public class RedisCacheConfig {
@@ -22,8 +24,12 @@ public class RedisCacheConfig {
         RedisCacheConfiguration redisCacheConfiguration = RedisCacheConfiguration.defaultCacheConfig()
                 .serializeKeysWith(
                         RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()))
-                .serializeValuesWith(RedisSerializationContext.SerializationPair
-                        .fromSerializer(GenericJacksonJsonRedisSerializer.builder().build()))
+                .serializeValuesWith(
+                        RedisSerializationContext.SerializationPair
+                                .fromSerializer(GenericJacksonJsonRedisSerializer.builder()
+                                        .enableDefaultTyping(BasicPolymorphicTypeValidator.builder()
+                                                .allowIfBaseType(Object.class).build())
+                                        .build()))
                 .entryTtl(Duration.ofDays(4L));
 
         return RedisCacheManager.RedisCacheManagerBuilder.fromConnectionFactory(cf)


### PR DESCRIPTION
  PR 본문:                                                                                                                                                       
              
  ## 개요                                 
                        
  Redis에 캐싱된 `FoundOneseoResDto` 조회 시 타입 정보 부재로 `LinkedHashMap`으로 역직렬화되어
  `ClassCastException`이 발생하는 문제를 수정합니다.
  `GET /api/oneseo/v3/oneseo/me` 엔드포인트에서 두 번째 요청부터 500 응답이 반환되던 이슈를 해결합니다.

  ## 본문

  기존 `GenericJacksonJsonRedisSerializer.builder().build()`는 직렬화 시 타입 메타데이터를 JSON에 포함하지 않습니다.
  캐시 미스 시에는 DB에서 정상 조회되지만, 이후 캐시 히트 시 Jackson이 타입 정보 없이 역직렬화를 시도하면서
  `FoundOneseoResDto` 대신 `LinkedHashMap`으로 복원되어 `ClassCastException`이 발생합니다.

  `enableDefaultTyping`을 적용하면 직렬화된 JSON에 `@class` 필드가 포함되어
  역직렬화 시 올바른 타입으로 복원됩니다.

  > [!IMPORTANT]
  > 배포 후 기존 캐시 키(`oneseo::*`) 삭제 필요
  > ```bash
  > redis-cli --scan --pattern "oneseo::*" | xargs redis-cli del
  > ```

  ### 변경

  - `RedisCacheConfig`: `GenericJacksonJsonRedisSerializer`에 `enableDefaultTyping` 적용으로 캐시 직렬화 시 타입 정보 포함



# RCA 룰

r: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)  
c: 웬만하면 반영해 주세요. (Comment)  
a: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)
