### PR TITLE
[oneseo] BasicPolymorphicTypeValidator의 허용 타입으로 java.util 허용

### DIFF
--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/controller/OneseoController.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/controller/OneseoController.java
@@ -6,6 +6,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 import org.apache.poi.ss.usermodel.Workbook;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -16,7 +17,6 @@ import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
-import org.springframework.validation.annotation.Validated;
 import team.themoment.hellogsmv3.domain.oneseo.dto.request.*;
 import team.themoment.hellogsmv3.domain.oneseo.dto.response.*;
 import team.themoment.hellogsmv3.domain.oneseo.entity.type.ScreeningCategory;

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/repository/custom/CustomOneseoRepository.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/repository/custom/CustomOneseoRepository.java
@@ -2,7 +2,6 @@ package team.themoment.hellogsmv3.domain.oneseo.repository.custom;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/repository/custom/impl/CustomOneseoRepositoryImpl.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/repository/custom/impl/CustomOneseoRepositoryImpl.java
@@ -12,7 +12,6 @@ import static team.themoment.hellogsmv3.domain.oneseo.entity.type.YesNo.YES;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 import org.springframework.data.domain.Page;

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/DownloadExcelService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/DownloadExcelService.java
@@ -285,8 +285,7 @@ public class DownloadExcelService {
         return (address != null ? address : "") + (detailAddress != null ? " " + detailAddress : "");
     }
 
-    private String convertGraduationType(
-            GraduationType graduationType) {
+    private String convertGraduationType(GraduationType graduationType) {
         if (graduationType == null)
             return "";
         return switch (graduationType) {

--- a/src/main/java/team/themoment/hellogsmv3/global/config/RedisCacheConfig.java
+++ b/src/main/java/team/themoment/hellogsmv3/global/config/RedisCacheConfig.java
@@ -31,10 +31,11 @@ public class RedisCacheConfig {
                         .fromSerializer(GenericJacksonJsonRedisSerializer.builder().build()))
                 .entryTtl(Duration.ofDays(4L));
 
-        RedisCacheConfiguration oneseoConfig = defaultConfig
-                .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(
-                        GenericJacksonJsonRedisSerializer.builder().enableDefaultTyping(BasicPolymorphicTypeValidator
-                                .builder().allowIfSubType("team.themoment.hellogsmv3").build()).build()));
+        RedisCacheConfiguration oneseoConfig = defaultConfig.serializeValuesWith(
+                RedisSerializationContext.SerializationPair.fromSerializer(GenericJacksonJsonRedisSerializer.builder()
+                        .enableDefaultTyping(BasicPolymorphicTypeValidator.builder()
+                                .allowIfSubType("team.themoment.hellogsmv3").allowIfSubType("java.util").build())
+                        .build()));
 
         return RedisCacheManager.RedisCacheManagerBuilder.fromConnectionFactory(cf).cacheDefaults(defaultConfig)
                 .withInitialCacheConfigurations(Map.of(ONESEO_CACHE_VALUE, oneseoConfig)).build();

--- a/src/main/java/team/themoment/hellogsmv3/global/config/RedisCacheConfig.java
+++ b/src/main/java/team/themoment/hellogsmv3/global/config/RedisCacheConfig.java
@@ -34,7 +34,8 @@ public class RedisCacheConfig {
         RedisCacheConfiguration oneseoConfig = defaultConfig.serializeValuesWith(
                 RedisSerializationContext.SerializationPair.fromSerializer(GenericJacksonJsonRedisSerializer.builder()
                         .enableDefaultTyping(BasicPolymorphicTypeValidator.builder()
-                                .allowIfSubType("team.themoment.hellogsmv3").allowIfSubType("java.util").build())
+                                .allowIfSubType("team.themoment.hellogsmv3").allowIfSubType(java.util.Collection.class)
+                                .allowIfSubType(java.util.Map.class).build())
                         .build()));
 
         return RedisCacheManager.RedisCacheManagerBuilder.fromConnectionFactory(cf).cacheDefaults(defaultConfig)


### PR DESCRIPTION
## 개요
RedisCacheConfig에서 BasicPolymorphicTypeValidator의 허용 타입을 `team.themoment.hellogsmv3` 패키지로만 제한했는데, List 필드가 Redis에 저장될 때 타입 정보가 ["java.util.ArrayList", [...]] 형태로 저장이 되어, 역직렬화 시 java.util.ArrayList가 허용 목록에 없어서 검증 실패 후 500 에러가 발생했습니다.

## 본문
RedisCacheConfig.java에서 allowIfSubType("java.util")를 추가하였습니다.
```java
// 변경 전                              
  BasicPolymorphicTypeValidator.builder()
      .allowIfSubType("team.themoment.hellogsmv3")                                                                                                                     
      .build()
```
```java
// 변경 후  
BasicPolymorphicTypeValidator.builder()
    .allowIfSubType("team.themoment.hellogsmv3")
    .allowIfSubType("java.util")  // ArrayList, HashMap 등 허용
    .build()
```

---

# RCA 룰

r: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)  
c: 웬만하면 반영해 주세요. (Comment)  
a: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)
