### PR TITLE
[global] the-sdk 제거 및 로컬 구현체 복원

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,6 @@ configurations {
 
 repositories {
 	mavenCentral()
-	maven { url 'https://jitpack.io' }
 }
 
 dependencies {
@@ -104,8 +103,6 @@ dependencies {
 	/** open feign **/
 	implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
 
-	/* sdk */
-	implementation("com.github.themoment-team:the-sdk:1.5")
 }
 
 ext {

--- a/src/main/java/team/themoment/hellogsmv3/domain/common/operation/controller/OperationTestResultController.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/common/operation/controller/OperationTestResultController.java
@@ -15,7 +15,7 @@ import team.themoment.hellogsmv3.domain.common.operation.dto.response.AnnounceTe
 import team.themoment.hellogsmv3.domain.common.operation.service.AnnounceFirstTestResultService;
 import team.themoment.hellogsmv3.domain.common.operation.service.AnnounceSecondTestResultService;
 import team.themoment.hellogsmv3.domain.common.operation.service.QueryAnnounceTestResultService;
-import team.themoment.sdk.response.CommonApiResponse;
+import team.themoment.hellogsmv3.global.common.response.CommonApiResponse;
 
 @Tag(name = "Operation API", description = "결과 발표 관련 operation API입니다.")
 @RestController

--- a/src/main/java/team/themoment/hellogsmv3/domain/common/operation/service/AnnounceFirstTestResultService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/common/operation/service/AnnounceFirstTestResultService.java
@@ -12,8 +12,8 @@ import lombok.RequiredArgsConstructor;
 import team.themoment.hellogsmv3.domain.common.operation.entity.OperationTestResult;
 import team.themoment.hellogsmv3.domain.common.operation.repository.OperationTestResultRepository;
 import team.themoment.hellogsmv3.domain.oneseo.repository.EntranceTestResultRepository;
+import team.themoment.hellogsmv3.global.exception.error.ExpectedException;
 import team.themoment.hellogsmv3.global.security.data.ScheduleEnvironment;
-import team.themoment.sdk.exception.ExpectedException;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/team/themoment/hellogsmv3/domain/common/operation/service/AnnounceSecondTestResultService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/common/operation/service/AnnounceSecondTestResultService.java
@@ -13,8 +13,8 @@ import lombok.RequiredArgsConstructor;
 import team.themoment.hellogsmv3.domain.common.operation.entity.OperationTestResult;
 import team.themoment.hellogsmv3.domain.common.operation.repository.OperationTestResultRepository;
 import team.themoment.hellogsmv3.domain.oneseo.repository.EntranceTestResultRepository;
+import team.themoment.hellogsmv3.global.exception.error.ExpectedException;
 import team.themoment.hellogsmv3.global.security.data.ScheduleEnvironment;
-import team.themoment.sdk.exception.ExpectedException;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/team/themoment/hellogsmv3/domain/common/operation/service/QueryAnnounceTestResultService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/common/operation/service/QueryAnnounceTestResultService.java
@@ -8,7 +8,7 @@ import lombok.RequiredArgsConstructor;
 import team.themoment.hellogsmv3.domain.common.operation.dto.response.AnnounceTestResultResDto;
 import team.themoment.hellogsmv3.domain.common.operation.entity.OperationTestResult;
 import team.themoment.hellogsmv3.domain.common.operation.repository.OperationTestResultRepository;
-import team.themoment.sdk.exception.ExpectedException;
+import team.themoment.hellogsmv3.global.exception.error.ExpectedException;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/team/themoment/hellogsmv3/domain/common/utility/controller/UtilityController.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/common/utility/controller/UtilityController.java
@@ -13,7 +13,7 @@ import team.themoment.hellogsmv3.domain.common.utility.service.DeleteMemberServi
 import team.themoment.hellogsmv3.domain.common.utility.service.DeleteOneseoService;
 import team.themoment.hellogsmv3.domain.common.utility.service.ModifyMemberRoleService;
 import team.themoment.hellogsmv3.domain.member.entity.type.Role;
-import team.themoment.sdk.response.CommonApiResponse;
+import team.themoment.hellogsmv3.global.common.response.CommonApiResponse;
 
 @RestController
 @RequestMapping("/utility/v3")

--- a/src/main/java/team/themoment/hellogsmv3/domain/common/utility/service/DeleteMemberService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/common/utility/service/DeleteMemberService.java
@@ -18,7 +18,7 @@ import team.themoment.hellogsmv3.domain.member.repository.CodeRepository;
 import team.themoment.hellogsmv3.domain.member.repository.MemberRepository;
 import team.themoment.hellogsmv3.domain.oneseo.entity.Oneseo;
 import team.themoment.hellogsmv3.domain.oneseo.repository.OneseoRepository;
-import team.themoment.sdk.exception.ExpectedException;
+import team.themoment.hellogsmv3.global.exception.error.ExpectedException;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/team/themoment/hellogsmv3/domain/common/utility/service/DeleteOneseoService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/common/utility/service/DeleteOneseoService.java
@@ -10,7 +10,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
 import team.themoment.hellogsmv3.domain.oneseo.repository.OneseoRepository;
-import team.themoment.sdk.exception.ExpectedException;
+import team.themoment.hellogsmv3.global.exception.error.ExpectedException;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/team/themoment/hellogsmv3/domain/common/utility/service/ModifyMemberRoleService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/common/utility/service/ModifyMemberRoleService.java
@@ -9,7 +9,7 @@ import lombok.RequiredArgsConstructor;
 import team.themoment.hellogsmv3.domain.member.entity.Member;
 import team.themoment.hellogsmv3.domain.member.entity.type.Role;
 import team.themoment.hellogsmv3.domain.member.repository.MemberRepository;
-import team.themoment.sdk.exception.ExpectedException;
+import team.themoment.hellogsmv3.global.exception.error.ExpectedException;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/team/themoment/hellogsmv3/domain/member/controller/MemberController.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/member/controller/MemberController.java
@@ -21,8 +21,8 @@ import team.themoment.hellogsmv3.domain.member.service.*;
 import team.themoment.hellogsmv3.domain.member.service.impl.GenerateCodeServiceImpl;
 import team.themoment.hellogsmv3.domain.member.service.impl.GenerateTestCodeServiceImpl;
 import team.themoment.hellogsmv3.global.common.handler.annotation.AuthRequest;
+import team.themoment.hellogsmv3.global.common.response.CommonApiResponse;
 import team.themoment.hellogsmv3.global.security.auth.AuthenticatedUserManager;
-import team.themoment.sdk.response.CommonApiResponse;
 
 @Tag(name = "Member API", description = "맴버 관련 API입니다.")
 @RestController

--- a/src/main/java/team/themoment/hellogsmv3/domain/member/service/AuthenticateCodeService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/member/service/AuthenticateCodeService.java
@@ -9,7 +9,7 @@ import team.themoment.hellogsmv3.domain.member.dto.request.AuthenticateCodeReqDt
 import team.themoment.hellogsmv3.domain.member.entity.AuthenticationCode;
 import team.themoment.hellogsmv3.domain.member.entity.type.AuthCodeType;
 import team.themoment.hellogsmv3.domain.member.repository.CodeRepository;
-import team.themoment.sdk.exception.ExpectedException;
+import team.themoment.hellogsmv3.global.exception.error.ExpectedException;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/team/themoment/hellogsmv3/domain/member/service/CommonCodeService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/member/service/CommonCodeService.java
@@ -7,7 +7,7 @@ import lombok.RequiredArgsConstructor;
 import team.themoment.hellogsmv3.domain.member.entity.AuthenticationCode;
 import team.themoment.hellogsmv3.domain.member.entity.type.AuthCodeType;
 import team.themoment.hellogsmv3.domain.member.repository.CodeRepository;
-import team.themoment.sdk.exception.ExpectedException;
+import team.themoment.hellogsmv3.global.exception.error.ExpectedException;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/team/themoment/hellogsmv3/domain/member/service/CreateMemberService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/member/service/CreateMemberService.java
@@ -16,8 +16,8 @@ import team.themoment.hellogsmv3.domain.member.entity.Member;
 import team.themoment.hellogsmv3.domain.member.entity.type.Role;
 import team.themoment.hellogsmv3.domain.member.repository.MemberRepository;
 import team.themoment.hellogsmv3.domain.oneseo.repository.*;
+import team.themoment.hellogsmv3.global.exception.error.ExpectedException;
 import team.themoment.hellogsmv3.global.security.data.ScheduleEnvironment;
-import team.themoment.sdk.exception.ExpectedException;
 
 @Service
 @Slf4j

--- a/src/main/java/team/themoment/hellogsmv3/domain/member/service/MemberService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/member/service/MemberService.java
@@ -6,7 +6,7 @@ import org.springframework.stereotype.Service;
 import lombok.RequiredArgsConstructor;
 import team.themoment.hellogsmv3.domain.member.entity.Member;
 import team.themoment.hellogsmv3.domain.member.repository.MemberRepository;
-import team.themoment.sdk.exception.ExpectedException;
+import team.themoment.hellogsmv3.global.exception.error.ExpectedException;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/team/themoment/hellogsmv3/domain/member/service/QueryMemberAuthInfoByIdService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/member/service/QueryMemberAuthInfoByIdService.java
@@ -8,7 +8,7 @@ import lombok.RequiredArgsConstructor;
 import team.themoment.hellogsmv3.domain.member.dto.response.FoundMemberAuthInfoResDto;
 import team.themoment.hellogsmv3.domain.member.entity.Member;
 import team.themoment.hellogsmv3.domain.member.repository.MemberRepository;
-import team.themoment.sdk.exception.ExpectedException;
+import team.themoment.hellogsmv3.global.exception.error.ExpectedException;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/team/themoment/hellogsmv3/domain/member/service/QueryMemberByIdService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/member/service/QueryMemberByIdService.java
@@ -8,7 +8,7 @@ import lombok.RequiredArgsConstructor;
 import team.themoment.hellogsmv3.domain.member.dto.response.FoundMemberResDto;
 import team.themoment.hellogsmv3.domain.member.entity.Member;
 import team.themoment.hellogsmv3.domain.member.repository.MemberRepository;
-import team.themoment.sdk.exception.ExpectedException;
+import team.themoment.hellogsmv3.global.exception.error.ExpectedException;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/team/themoment/hellogsmv3/domain/member/service/impl/GenerateCodeServiceImpl.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/member/service/impl/GenerateCodeServiceImpl.java
@@ -13,7 +13,7 @@ import team.themoment.hellogsmv3.domain.member.entity.AuthenticationCode;
 import team.themoment.hellogsmv3.domain.member.repository.CodeRepository;
 import team.themoment.hellogsmv3.domain.member.service.GenerateCodeService;
 import team.themoment.hellogsmv3.domain.member.service.SendCodeNotificationService;
-import team.themoment.sdk.exception.ExpectedException;
+import team.themoment.hellogsmv3.global.exception.error.ExpectedException;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/controller/OneseoController.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/controller/OneseoController.java
@@ -6,7 +6,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 import org.apache.poi.ss.usermodel.Workbook;
-import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -17,6 +16,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
+import org.springframework.validation.annotation.Validated;
 import team.themoment.hellogsmv3.domain.oneseo.dto.request.*;
 import team.themoment.hellogsmv3.domain.oneseo.dto.response.*;
 import team.themoment.hellogsmv3.domain.oneseo.entity.type.ScreeningCategory;
@@ -28,7 +28,7 @@ import team.themoment.hellogsmv3.domain.oneseo.service.ModifyRealOneseoArrivedYn
 import team.themoment.hellogsmv3.domain.oneseo.service.QueryOneseoByIdService;
 import team.themoment.hellogsmv3.domain.oneseo.service.SearchOneseoService;
 import team.themoment.hellogsmv3.global.common.handler.annotation.AuthRequest;
-import team.themoment.sdk.response.CommonApiResponse;
+import team.themoment.hellogsmv3.global.common.response.CommonApiResponse;
 
 @Tag(name = "Oneseo API", description = "원서 관련 API입니다.")
 @Validated

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/repository/custom/CustomOneseoRepository.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/repository/custom/CustomOneseoRepository.java
@@ -2,6 +2,7 @@ package team.themoment.hellogsmv3.domain.oneseo.repository.custom;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/repository/custom/impl/CustomOneseoRepositoryImpl.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/repository/custom/impl/CustomOneseoRepositoryImpl.java
@@ -12,6 +12,7 @@ import static team.themoment.hellogsmv3.domain.oneseo.entity.type.YesNo.YES;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import org.springframework.data.domain.Page;

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/CreateOneseoService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/CreateOneseoService.java
@@ -24,9 +24,9 @@ import team.themoment.hellogsmv3.domain.oneseo.entity.type.DesiredMajors;
 import team.themoment.hellogsmv3.domain.oneseo.entity.type.GraduationType;
 import team.themoment.hellogsmv3.domain.oneseo.event.OneseoApplyEvent;
 import team.themoment.hellogsmv3.domain.oneseo.repository.*;
+import team.themoment.hellogsmv3.global.exception.error.ExpectedException;
 import team.themoment.hellogsmv3.global.thirdParty.feign.client.dto.request.LambdaScoreCalculatorReqDto;
 import team.themoment.hellogsmv3.global.thirdParty.feign.client.lambda.LambdaScoreCalculatorClient;
-import team.themoment.sdk.exception.ExpectedException;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/DownloadExcelService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/DownloadExcelService.java
@@ -31,7 +31,7 @@ import team.themoment.hellogsmv3.domain.oneseo.entity.type.Major;
 import team.themoment.hellogsmv3.domain.oneseo.entity.type.Screening;
 import team.themoment.hellogsmv3.domain.oneseo.entity.type.YesNo;
 import team.themoment.hellogsmv3.domain.oneseo.repository.OneseoRepository;
-import team.themoment.sdk.exception.ExpectedException;
+import team.themoment.hellogsmv3.global.exception.error.ExpectedException;
 
 @Service
 @RequiredArgsConstructor
@@ -285,7 +285,8 @@ public class DownloadExcelService {
         return (address != null ? address : "") + (detailAddress != null ? " " + detailAddress : "");
     }
 
-    private String convertGraduationType(GraduationType graduationType) {
+    private String convertGraduationType(
+            GraduationType graduationType) {
         if (graduationType == null)
             return "";
         return switch (graduationType) {

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyEntranceIntentionService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyEntranceIntentionService.java
@@ -9,7 +9,7 @@ import team.themoment.hellogsmv3.domain.member.service.MemberService;
 import team.themoment.hellogsmv3.domain.oneseo.dto.request.EntranceIntentionReqDto;
 import team.themoment.hellogsmv3.domain.oneseo.entity.Oneseo;
 import team.themoment.hellogsmv3.domain.oneseo.repository.OneseoRepository;
-import team.themoment.sdk.exception.ExpectedException;
+import team.themoment.hellogsmv3.global.exception.error.ExpectedException;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyOneseoService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyOneseoService.java
@@ -22,9 +22,9 @@ import team.themoment.hellogsmv3.domain.oneseo.entity.type.DesiredMajors;
 import team.themoment.hellogsmv3.domain.oneseo.entity.type.GraduationType;
 import team.themoment.hellogsmv3.domain.oneseo.entity.type.Screening;
 import team.themoment.hellogsmv3.domain.oneseo.repository.*;
+import team.themoment.hellogsmv3.global.exception.error.ExpectedException;
 import team.themoment.hellogsmv3.global.thirdParty.feign.client.dto.request.LambdaScoreCalculatorReqDto;
 import team.themoment.hellogsmv3.global.thirdParty.feign.client.lambda.LambdaScoreCalculatorClient;
-import team.themoment.sdk.exception.ExpectedException;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/OneseoService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/OneseoService.java
@@ -23,8 +23,8 @@ import team.themoment.hellogsmv3.domain.oneseo.entity.type.ScreeningCategory;
 import team.themoment.hellogsmv3.domain.oneseo.entity.type.YesNo;
 import team.themoment.hellogsmv3.domain.oneseo.repository.EntranceTestResultRepository;
 import team.themoment.hellogsmv3.domain.oneseo.repository.OneseoRepository;
+import team.themoment.hellogsmv3.global.exception.error.ExpectedException;
 import team.themoment.hellogsmv3.global.security.data.ScheduleEnvironment;
-import team.themoment.sdk.exception.ExpectedException;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/OneseoTempStorageService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/OneseoTempStorageService.java
@@ -19,7 +19,7 @@ import team.themoment.hellogsmv3.domain.oneseo.dto.response.FoundOneseoResDto;
 import team.themoment.hellogsmv3.domain.oneseo.dto.response.MiddleSchoolAchievementResDto;
 import team.themoment.hellogsmv3.domain.oneseo.dto.response.OneseoPrivacyDetailResDto;
 import team.themoment.hellogsmv3.domain.oneseo.repository.OneseoRepository;
-import team.themoment.sdk.exception.ExpectedException;
+import team.themoment.hellogsmv3.global.exception.error.ExpectedException;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/UploadExcelService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/UploadExcelService.java
@@ -17,7 +17,7 @@ import team.themoment.hellogsmv3.domain.oneseo.dto.internal.SecondTestResultDto;
 import team.themoment.hellogsmv3.domain.oneseo.entity.EntranceTestResult;
 import team.themoment.hellogsmv3.domain.oneseo.repository.EntranceTestResultRepository;
 import team.themoment.hellogsmv3.domain.oneseo.repository.OneseoRepository;
-import team.themoment.sdk.exception.ExpectedException;
+import team.themoment.hellogsmv3.global.exception.error.ExpectedException;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/team/themoment/hellogsmv3/global/common/handler/AuthenticationArgumentResolver.java
+++ b/src/main/java/team/themoment/hellogsmv3/global/common/handler/AuthenticationArgumentResolver.java
@@ -10,7 +10,7 @@ import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.method.support.ModelAndViewContainer;
 
 import team.themoment.hellogsmv3.global.common.handler.annotation.AuthRequest;
-import team.themoment.sdk.exception.ExpectedException;
+import team.themoment.hellogsmv3.global.exception.error.ExpectedException;
 
 public class AuthenticationArgumentResolver implements HandlerMethodArgumentResolver {
     @Override

--- a/src/main/java/team/themoment/hellogsmv3/global/common/logging/CachedBodyRequestWrapper.java
+++ b/src/main/java/team/themoment/hellogsmv3/global/common/logging/CachedBodyRequestWrapper.java
@@ -1,0 +1,64 @@
+package team.themoment.hellogsmv3.global.common.logging;
+
+import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+
+import org.springframework.util.StreamUtils;
+
+import jakarta.servlet.ReadListener;
+import jakarta.servlet.ServletInputStream;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequestWrapper;
+import lombok.Getter;
+
+/**
+ * HttpServletRequest의 바디를 미리 읽어 캐시하고, 이후 여러 번 읽을 수 있도록 재생 가능한
+ * InputStream/Reader를 제공하는 래퍼
+ */
+@Getter
+public class CachedBodyRequestWrapper extends HttpServletRequestWrapper {
+
+    private final byte[] cachedBody;
+
+    public CachedBodyRequestWrapper(HttpServletRequest request) throws IOException {
+        super(request);
+        this.cachedBody = StreamUtils.copyToByteArray(request.getInputStream());
+    }
+
+    @Override
+    public ServletInputStream getInputStream() {
+        final ByteArrayInputStream bais = new ByteArrayInputStream(this.cachedBody);
+        return new ServletInputStream() {
+            @Override
+            public int read() {
+                return bais.read();
+            }
+
+            @Override
+            public boolean isFinished() {
+                return bais.available() == 0;
+            }
+
+            @Override
+            public boolean isReady() {
+                return true;
+            }
+
+            @Override
+            public void setReadListener(ReadListener readListener) {
+            }
+        };
+    }
+
+    @Override
+    public BufferedReader getReader() {
+        Charset charset = getCharacterEncoding() != null
+                ? Charset.forName(getCharacterEncoding())
+                : StandardCharsets.UTF_8;
+        return new BufferedReader(new InputStreamReader(getInputStream(), charset));
+    }
+}

--- a/src/main/java/team/themoment/hellogsmv3/global/common/logging/LoggingFilter.java
+++ b/src/main/java/team/themoment/hellogsmv3/global/common/logging/LoggingFilter.java
@@ -1,0 +1,157 @@
+package team.themoment.hellogsmv3.global.common.logging;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.UUID;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+import org.springframework.util.AntPathMatcher;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+import org.springframework.web.util.ContentCachingResponseWrapper;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+@Component
+public class LoggingFilter extends OncePerRequestFilter {
+
+    private static final Logger log = LoggerFactory.getLogger(LoggingFilter.class);
+
+    private static final String[] NOT_LOGGING_URL = {"/api-docs/**", "/swagger-ui/**",
+            "/hello-management/prometheus/**"};
+
+    private final AntPathMatcher matcher = new AntPathMatcher();
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) {
+
+        if (isNotLoggingURL(request.getRequestURI())) {
+            try {
+                filterChain.doFilter(request, response);
+            } catch (Exception e) {
+                log.error("로깅 제외 경로 예외", e);
+            }
+
+            return;
+        }
+
+        // 멀티파트 요청은 바디 로깅/캐싱 생략, 메타데이터만 기록
+        if (isMultipart(request)) {
+            ContentCachingResponseWrapper responseWrapper = new ContentCachingResponseWrapper(response);
+            UUID logId = UUID.randomUUID();
+            long startTime = System.currentTimeMillis();
+            try {
+                requestLoggingMultipart(request, logId);
+                filterChain.doFilter(request, responseWrapper);
+            } catch (Exception e) {
+                log.error("LoggingFilter의 FilterChain에서 예외가 발생했습니다.", e);
+            } finally {
+                responseLogging(responseWrapper, startTime, logId);
+                try {
+                    responseWrapper.copyBodyToResponse();
+                } catch (IOException e) {
+                    log.error("LoggingFilter에서 response body를 출력하는 도중 예외가 발생했습니다.", e);
+                }
+            }
+            return;
+        }
+
+        CachedBodyRequestWrapper cachedRequest;
+        try {
+            cachedRequest = new CachedBodyRequestWrapper(request);
+        } catch (IOException e) {
+            log.error("요청 바디 캐싱 중 예외 발생 - 원본 요청으로 진행합니다.", e);
+            try {
+                filterChain.doFilter(request, response);
+            } catch (Exception ex) {
+                log.error("LoggingFilter의 FilterChain에서 예외가 발생했습니다.", ex);
+            }
+            return;
+        }
+
+        ContentCachingResponseWrapper responseWrapper = new ContentCachingResponseWrapper(response);
+
+        UUID logId = UUID.randomUUID();
+        long startTime = System.currentTimeMillis();
+
+        try {
+            requestLogging(cachedRequest, logId, cachedRequest.getCachedBody());
+            filterChain.doFilter(cachedRequest, responseWrapper);
+        } catch (Exception e) {
+            log.error("LoggingFilter의 FilterChain에서 예외가 발생했습니다.", e);
+        } finally {
+            responseLogging(responseWrapper, startTime, logId);
+            try {
+                responseWrapper.copyBodyToResponse();
+            } catch (IOException e) {
+                log.error("LoggingFilter에서 response body를 출력하는 도중 예외가 발생했습니다.", e);
+            }
+        }
+    }
+
+    private boolean isNotLoggingURL(String requestURI) {
+        return Arrays.stream(NOT_LOGGING_URL).anyMatch(pattern -> matcher.match(pattern, requestURI));
+    }
+
+    private boolean isMultipart(HttpServletRequest request) {
+        String contentType = request.getContentType();
+        return contentType != null && contentType.toLowerCase().startsWith("multipart/");
+    }
+
+    private void requestLogging(HttpServletRequest request, UUID logId, byte[] cachedBody) {
+        log.info(
+                "Log-ID: {}, IP: {}, URI: {}, Http-Method: {}, Params: {}, Content-Type: {}, User-Cookies: {}, User-Agent: {}, Request-Body: {}",
+                logId,
+                request.getRemoteAddr(),
+                request.getRequestURI(),
+                request.getMethod(),
+                request.getQueryString(),
+                request.getContentType(),
+                request.getCookies() != null ? String.join(", ", getCookiesAsString(request.getCookies())) : "[none]",
+                request.getHeader("User-Agent"),
+                getRequestBody(cachedBody));
+    }
+
+    private void requestLoggingMultipart(HttpServletRequest request, UUID logId) {
+        String contentLength = request.getHeader("Content-Length");
+        log.info(
+                "Log-ID: {}, IP: {}, URI: {}, Http-Method: {}, Params: {}, Content-Type: {}, Content-Length: {}, User-Cookies: {}, User-Agent: {}, Request-Body: {}",
+                logId,
+                request.getRemoteAddr(),
+                request.getRequestURI(),
+                request.getMethod(),
+                request.getQueryString(),
+                request.getContentType(),
+                contentLength != null ? contentLength : "[unknown]",
+                request.getCookies() != null ? String.join(", ", getCookiesAsString(request.getCookies())) : "[none]",
+                request.getHeader("User-Agent"),
+                "[multipart omitted]");
+    }
+
+    private void responseLogging(ContentCachingResponseWrapper response, long startTime, UUID logId) {
+        long endTime = System.currentTimeMillis();
+        long responseTime = endTime - startTime;
+        log.info("Log-ID: {}, Status-Code: {}, Content-Type: {}, Response Time: {}ms, Response-Body: {}",
+                logId,
+                response.getStatus(),
+                response.getContentType(),
+                responseTime,
+                new String(response.getContentAsByteArray(), StandardCharsets.UTF_8));
+    }
+
+    private String getRequestBody(byte[] byteArrayContent) {
+        String oneLineContent = new String(byteArrayContent, StandardCharsets.UTF_8).replaceAll("\\s", "");
+        return StringUtils.hasText(oneLineContent) ? oneLineContent : "[empty]";
+    }
+
+    private String[] getCookiesAsString(Cookie[] cookies) {
+        return Arrays.stream(cookies).map(cookie -> String.format("%s=%s", cookie.getName(), cookie.getValue()))
+                .toArray(String[]::new);
+    }
+}

--- a/src/main/java/team/themoment/hellogsmv3/global/common/response/ApiResponseWrapper.java
+++ b/src/main/java/team/themoment/hellogsmv3/global/common/response/ApiResponseWrapper.java
@@ -14,8 +14,6 @@ import org.springframework.util.AntPathMatcher;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseBodyAdvice;
 
-import team.themoment.sdk.response.CommonApiResponse;
-
 @RestControllerAdvice
 public class ApiResponseWrapper implements ResponseBodyAdvice<Object> {
 

--- a/src/main/java/team/themoment/hellogsmv3/global/common/response/CommonApiResponse.java
+++ b/src/main/java/team/themoment/hellogsmv3/global/common/response/CommonApiResponse.java
@@ -1,0 +1,43 @@
+package team.themoment.hellogsmv3.global.common.response;
+
+import org.springframework.http.HttpStatus;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.annotation.Nonnull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class CommonApiResponse<T> {
+
+    @Schema(description = "상태 메시지", nullable = false, example = "OK")
+    HttpStatus status;
+
+    @Schema(description = "상태 코드", nullable = false, example = "200")
+    int code;
+
+    @Schema(description = "메시지", nullable = false, example = "완료되었습니다.")
+    String message;
+
+    @Schema(description = "데이터", nullable = true)
+    @JsonInclude(Include.NON_NULL)
+    T data;
+
+    public static CommonApiResponse success(@Nonnull String message) {
+        return new CommonApiResponse(HttpStatus.OK, HttpStatus.OK.value(), message, null);
+    }
+
+    public static CommonApiResponse created(@Nonnull String message) {
+        return new CommonApiResponse(HttpStatus.CREATED, HttpStatus.CREATED.value(), message, null);
+    }
+
+    public static CommonApiResponse error(@Nonnull String message, @Nonnull HttpStatus status) {
+        return new CommonApiResponse(status, status.value(), message, null);
+    }
+}

--- a/src/main/java/team/themoment/hellogsmv3/global/config/SwaggerConfig.java
+++ b/src/main/java/team/themoment/hellogsmv3/global/config/SwaggerConfig.java
@@ -20,7 +20,7 @@ import io.swagger.v3.oas.models.media.Schema;
 import io.swagger.v3.oas.models.parameters.Parameter;
 import lombok.SneakyThrows;
 import team.themoment.hellogsmv3.global.common.handler.annotation.AuthRequest;
-import team.themoment.sdk.response.CommonApiResponse;
+import team.themoment.hellogsmv3.global.common.response.CommonApiResponse;
 
 @OpenAPIDefinition(info = @Info(title = "Hello, GSM 2025", description = "광주소프트웨어마이스터고등학교 입학지원 시스템", version = "v1"))
 @Configuration

--- a/src/main/java/team/themoment/hellogsmv3/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/team/themoment/hellogsmv3/global/exception/GlobalExceptionHandler.java
@@ -15,11 +15,19 @@ import org.springframework.web.servlet.NoHandlerFoundException;
 import jakarta.validation.ConstraintViolationException;
 import lombok.extern.slf4j.Slf4j;
 import net.minidev.json.JSONObject;
-import team.themoment.sdk.response.CommonApiResponse;
+import team.themoment.hellogsmv3.global.common.response.CommonApiResponse;
+import team.themoment.hellogsmv3.global.exception.error.ExpectedException;
 
 @Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
+
+    @ExceptionHandler(ExpectedException.class)
+    private CommonApiResponse expectedException(ExpectedException ex) {
+        log.warn("ExpectedException : {} ", ex.getMessage());
+        log.trace("ExpectedException Details : ", ex);
+        return CommonApiResponse.error(ex.getMessage(), ex.getStatusCode());
+    }
 
     @ExceptionHandler({MethodArgumentNotValidException.class, HttpMessageNotReadableException.class,
             ConstraintViolationException.class, MethodArgumentTypeMismatchException.class})

--- a/src/main/java/team/themoment/hellogsmv3/global/exception/error/ExpectedException.java
+++ b/src/main/java/team/themoment/hellogsmv3/global/exception/error/ExpectedException.java
@@ -1,0 +1,25 @@
+package team.themoment.hellogsmv3.global.exception.error;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
+
+@Getter
+public class ExpectedException extends RuntimeException {
+
+    private final HttpStatus statusCode;
+
+    public ExpectedException(String message, HttpStatus statusCode) {
+        super(message);
+        this.statusCode = statusCode;
+    }
+
+    public ExpectedException(HttpStatus statusCode) {
+        this(statusCode.getReasonPhrase(), statusCode);
+    }
+
+    @Override
+    public synchronized Throwable fillInStackTrace() {
+        return this;
+    }
+}

--- a/src/main/java/team/themoment/hellogsmv3/global/security/SecurityConfig.java
+++ b/src/main/java/team/themoment/hellogsmv3/global/security/SecurityConfig.java
@@ -21,12 +21,12 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 import jakarta.servlet.Filter;
 import lombok.RequiredArgsConstructor;
 import team.themoment.hellogsmv3.domain.member.entity.type.Role;
+import team.themoment.hellogsmv3.global.common.logging.LoggingFilter;
 import team.themoment.hellogsmv3.global.security.data.AuthEnvironment;
 import team.themoment.hellogsmv3.global.security.data.ScheduleEnvironment;
 import team.themoment.hellogsmv3.global.security.filter.TimeBasedFilter;
 import team.themoment.hellogsmv3.global.security.handler.CustomAccessDeniedHandler;
 import team.themoment.hellogsmv3.global.security.handler.CustomAuthenticationEntryPoint;
-import team.themoment.sdk.logging.LoggingFilter;
 
 @Configuration
 @RequiredArgsConstructor

--- a/src/main/java/team/themoment/hellogsmv3/global/security/auth/AuthController.java
+++ b/src/main/java/team/themoment/hellogsmv3/global/security/auth/AuthController.java
@@ -15,10 +15,10 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import team.themoment.hellogsmv3.global.common.response.CommonApiResponse;
+import team.themoment.hellogsmv3.global.exception.error.ExpectedException;
 import team.themoment.hellogsmv3.global.security.auth.dto.request.OAuthCodeReqDto;
 import team.themoment.hellogsmv3.global.security.auth.service.OAuthAuthenticationService;
-import team.themoment.sdk.exception.ExpectedException;
-import team.themoment.sdk.response.CommonApiResponse;
 import tools.jackson.databind.ObjectMapper;
 
 @Tag(name = "Auth API", description = "인증 관련 API입니다.")

--- a/src/main/java/team/themoment/hellogsmv3/global/security/auth/service/OAuthProviderFactory.java
+++ b/src/main/java/team/themoment/hellogsmv3/global/security/auth/service/OAuthProviderFactory.java
@@ -8,8 +8,8 @@ import java.util.stream.Collectors;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
 
+import team.themoment.hellogsmv3.global.exception.error.ExpectedException;
 import team.themoment.hellogsmv3.global.security.auth.service.provider.OAuthProvider;
-import team.themoment.sdk.exception.ExpectedException;
 
 @Component
 public class OAuthProviderFactory {

--- a/src/main/java/team/themoment/hellogsmv3/global/security/auth/service/provider/GoogleOAuthProvider.java
+++ b/src/main/java/team/themoment/hellogsmv3/global/security/auth/service/provider/GoogleOAuthProvider.java
@@ -10,12 +10,12 @@ import org.springframework.util.StringUtils;
 
 import lombok.RequiredArgsConstructor;
 import team.themoment.hellogsmv3.domain.member.entity.type.AuthReferrerType;
+import team.themoment.hellogsmv3.global.exception.error.ExpectedException;
 import team.themoment.hellogsmv3.global.security.auth.dto.UserAuthInfo;
 import team.themoment.hellogsmv3.global.thirdParty.feign.client.dto.response.GoogleTokenResDto;
 import team.themoment.hellogsmv3.global.thirdParty.feign.client.dto.response.GoogleUserInfoResDto;
 import team.themoment.hellogsmv3.global.thirdParty.feign.client.oauth.google.GoogleOAuth2Client;
 import team.themoment.hellogsmv3.global.thirdParty.feign.client.oauth.google.GoogleUserInfoClient;
-import team.themoment.sdk.exception.ExpectedException;
 
 @Component
 @RequiredArgsConstructor

--- a/src/main/java/team/themoment/hellogsmv3/global/security/auth/service/provider/KakaoOAuthProvider.java
+++ b/src/main/java/team/themoment/hellogsmv3/global/security/auth/service/provider/KakaoOAuthProvider.java
@@ -10,12 +10,12 @@ import org.springframework.util.StringUtils;
 
 import lombok.RequiredArgsConstructor;
 import team.themoment.hellogsmv3.domain.member.entity.type.AuthReferrerType;
+import team.themoment.hellogsmv3.global.exception.error.ExpectedException;
 import team.themoment.hellogsmv3.global.security.auth.dto.UserAuthInfo;
 import team.themoment.hellogsmv3.global.thirdParty.feign.client.dto.response.KakaoTokenResDto;
 import team.themoment.hellogsmv3.global.thirdParty.feign.client.dto.response.KakaoUserInfoResDto;
 import team.themoment.hellogsmv3.global.thirdParty.feign.client.oauth.kakao.KakaoOAuth2Client;
 import team.themoment.hellogsmv3.global.thirdParty.feign.client.oauth.kakao.KakaoUserInfoClient;
-import team.themoment.sdk.exception.ExpectedException;
 
 @Component
 @RequiredArgsConstructor

--- a/src/main/java/team/themoment/hellogsmv3/global/security/filter/TimeBasedFilter.java
+++ b/src/main/java/team/themoment/hellogsmv3/global/security/filter/TimeBasedFilter.java
@@ -17,7 +17,7 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
-import team.themoment.sdk.response.CommonApiResponse;
+import team.themoment.hellogsmv3.global.common.response.CommonApiResponse;
 
 @Slf4j
 public class TimeBasedFilter extends OncePerRequestFilter {

--- a/src/main/java/team/themoment/hellogsmv3/global/security/handler/CustomAccessDeniedHandler.java
+++ b/src/main/java/team/themoment/hellogsmv3/global/security/handler/CustomAccessDeniedHandler.java
@@ -11,7 +11,7 @@ import org.springframework.stereotype.Component;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
-import team.themoment.sdk.response.CommonApiResponse;
+import team.themoment.hellogsmv3.global.common.response.CommonApiResponse;
 import tools.jackson.databind.ObjectMapper;
 
 @Component

--- a/src/main/java/team/themoment/hellogsmv3/global/security/handler/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/team/themoment/hellogsmv3/global/security/handler/CustomAuthenticationEntryPoint.java
@@ -11,7 +11,7 @@ import org.springframework.stereotype.Component;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
-import team.themoment.sdk.response.CommonApiResponse;
+import team.themoment.hellogsmv3.global.common.response.CommonApiResponse;
 import tools.jackson.databind.ObjectMapper;
 
 @Component

--- a/src/main/java/team/themoment/hellogsmv3/global/thirdParty/aws/s3/service/UploadImageService.java
+++ b/src/main/java/team/themoment/hellogsmv3/global/thirdParty/aws/s3/service/UploadImageService.java
@@ -18,9 +18,9 @@ import io.awspring.cloud.s3.S3Template;
 import lombok.RequiredArgsConstructor;
 import software.amazon.awssdk.awscore.exception.AwsServiceException;
 import software.amazon.awssdk.core.exception.SdkClientException;
+import team.themoment.hellogsmv3.global.exception.error.ExpectedException;
 import team.themoment.hellogsmv3.global.thirdParty.aws.s3.data.S3Environment;
 import team.themoment.hellogsmv3.global.thirdParty.aws.s3.dto.response.UploadImageResDto;
-import team.themoment.sdk.exception.ExpectedException;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/team/themoment/hellogsmv3/global/thirdParty/feign/config/FeignErrorDecoder.java
+++ b/src/main/java/team/themoment/hellogsmv3/global/thirdParty/feign/config/FeignErrorDecoder.java
@@ -12,7 +12,7 @@ import feign.FeignException;
 import feign.Response;
 import feign.codec.ErrorDecoder;
 import lombok.extern.slf4j.Slf4j;
-import team.themoment.sdk.exception.ExpectedException;
+import team.themoment.hellogsmv3.global.exception.error.ExpectedException;
 
 @Slf4j
 public class FeignErrorDecoder implements ErrorDecoder {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -121,25 +121,3 @@ discord-alarm:
 lambda-score-calculator:
   url: ${SCORE_CALCULATOR_SERVICE_URL}
   api-key: ${SCORE_CALCULATOR_API_KEY}
-
-sdk:
-  logging:
-    enabled: true
-    not-logging-urls:
-      - "/v3/api-docs/**"
-      - "/swagger-ui/**"
-
-  response:
-    enabled: true
-    not-wrapping-urls:
-      - "/v3/api-docs/**"
-
-  exception:
-    enabled: true
-    use-english-message: true
-
-  swagger:
-    enabled: true
-    title: "ReadyGSM API"
-    paths-to-match:
-      - "/v1/**"

--- a/src/test/java/team/themoment/hellogsmv3/domain/common/operation/service/AnnounceFirstTestResultServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/common/operation/service/AnnounceFirstTestResultServiceTest.java
@@ -21,8 +21,8 @@ import org.springframework.http.HttpStatus;
 import team.themoment.hellogsmv3.domain.common.operation.entity.OperationTestResult;
 import team.themoment.hellogsmv3.domain.common.operation.repository.OperationTestResultRepository;
 import team.themoment.hellogsmv3.domain.oneseo.repository.EntranceTestResultRepository;
+import team.themoment.hellogsmv3.global.exception.error.ExpectedException;
 import team.themoment.hellogsmv3.global.security.data.ScheduleEnvironment;
-import team.themoment.sdk.exception.ExpectedException;
 
 @DisplayName("AnnounceFirstTestResultService 클래스의")
 class AnnounceFirstTestResultServiceTest {

--- a/src/test/java/team/themoment/hellogsmv3/domain/common/operation/service/AnnounceSecondTestResultServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/common/operation/service/AnnounceSecondTestResultServiceTest.java
@@ -23,8 +23,8 @@ import org.springframework.http.HttpStatus;
 import team.themoment.hellogsmv3.domain.common.operation.entity.OperationTestResult;
 import team.themoment.hellogsmv3.domain.common.operation.repository.OperationTestResultRepository;
 import team.themoment.hellogsmv3.domain.oneseo.repository.EntranceTestResultRepository;
+import team.themoment.hellogsmv3.global.exception.error.ExpectedException;
 import team.themoment.hellogsmv3.global.security.data.ScheduleEnvironment;
-import team.themoment.sdk.exception.ExpectedException;
 
 @DisplayName("AnnounceSecondTestResultService 클래스의")
 class AnnounceSecondTestResultServiceTest {

--- a/src/test/java/team/themoment/hellogsmv3/domain/common/operation/service/QueryAnnounceTestResultServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/common/operation/service/QueryAnnounceTestResultServiceTest.java
@@ -19,7 +19,7 @@ import org.springframework.http.HttpStatus;
 import team.themoment.hellogsmv3.domain.common.operation.dto.response.AnnounceTestResultResDto;
 import team.themoment.hellogsmv3.domain.common.operation.entity.OperationTestResult;
 import team.themoment.hellogsmv3.domain.common.operation.repository.OperationTestResultRepository;
-import team.themoment.sdk.exception.ExpectedException;
+import team.themoment.hellogsmv3.global.exception.error.ExpectedException;
 
 @DisplayName("QueryAnnounceTestResultService 클래스의")
 public class QueryAnnounceTestResultServiceTest {

--- a/src/test/java/team/themoment/hellogsmv3/domain/common/utility/service/DeleteMemberServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/common/utility/service/DeleteMemberServiceTest.java
@@ -24,7 +24,7 @@ import team.themoment.hellogsmv3.domain.member.repository.CodeRepository;
 import team.themoment.hellogsmv3.domain.member.repository.MemberRepository;
 import team.themoment.hellogsmv3.domain.oneseo.entity.Oneseo;
 import team.themoment.hellogsmv3.domain.oneseo.repository.OneseoRepository;
-import team.themoment.sdk.exception.ExpectedException;
+import team.themoment.hellogsmv3.global.exception.error.ExpectedException;
 
 @DisplayName("DeleteMemberService 클래스의")
 class DeleteMemberServiceTest {

--- a/src/test/java/team/themoment/hellogsmv3/domain/common/utility/service/DeleteOneseoServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/common/utility/service/DeleteOneseoServiceTest.java
@@ -17,7 +17,7 @@ import org.mockito.MockitoAnnotations;
 import org.springframework.http.HttpStatus;
 
 import team.themoment.hellogsmv3.domain.oneseo.repository.OneseoRepository;
-import team.themoment.sdk.exception.ExpectedException;
+import team.themoment.hellogsmv3.global.exception.error.ExpectedException;
 
 @DisplayName("DeleteOneseoService 클래스의")
 class DeleteOneseoServiceTest {

--- a/src/test/java/team/themoment/hellogsmv3/domain/common/utility/service/ModifyMemberRoleServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/common/utility/service/ModifyMemberRoleServiceTest.java
@@ -19,7 +19,7 @@ import org.springframework.http.HttpStatus;
 import team.themoment.hellogsmv3.domain.member.entity.Member;
 import team.themoment.hellogsmv3.domain.member.entity.type.Role;
 import team.themoment.hellogsmv3.domain.member.repository.MemberRepository;
-import team.themoment.sdk.exception.ExpectedException;
+import team.themoment.hellogsmv3.global.exception.error.ExpectedException;
 
 @DisplayName("ModifyMemberRoleService 클래스의")
 class ModifyMemberRoleServiceTest {

--- a/src/test/java/team/themoment/hellogsmv3/domain/member/service/AuthenticateCodeServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/member/service/AuthenticateCodeServiceTest.java
@@ -22,7 +22,7 @@ import org.springframework.http.HttpStatus;
 import team.themoment.hellogsmv3.domain.member.dto.request.AuthenticateCodeReqDto;
 import team.themoment.hellogsmv3.domain.member.entity.AuthenticationCode;
 import team.themoment.hellogsmv3.domain.member.repository.CodeRepository;
-import team.themoment.sdk.exception.ExpectedException;
+import team.themoment.hellogsmv3.global.exception.error.ExpectedException;
 
 @DisplayName("AuthenticateCodeService 클래스의")
 public class AuthenticateCodeServiceTest {

--- a/src/test/java/team/themoment/hellogsmv3/domain/member/service/CommonCodeServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/member/service/CommonCodeServiceTest.java
@@ -22,7 +22,7 @@ import org.springframework.http.HttpStatus;
 
 import team.themoment.hellogsmv3.domain.member.entity.AuthenticationCode;
 import team.themoment.hellogsmv3.domain.member.repository.CodeRepository;
-import team.themoment.sdk.exception.ExpectedException;
+import team.themoment.hellogsmv3.global.exception.error.ExpectedException;
 
 @DisplayName("CommonCodeService 클래스의")
 class CommonCodeServiceTest {

--- a/src/test/java/team/themoment/hellogsmv3/domain/member/service/CreateMemberServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/member/service/CreateMemberServiceTest.java
@@ -29,8 +29,8 @@ import team.themoment.hellogsmv3.domain.member.entity.type.Sex;
 import team.themoment.hellogsmv3.domain.member.repository.MemberRepository;
 import team.themoment.hellogsmv3.domain.oneseo.repository.EntranceTestResultRepository;
 import team.themoment.hellogsmv3.domain.oneseo.repository.OneseoRepository;
+import team.themoment.hellogsmv3.global.exception.error.ExpectedException;
 import team.themoment.hellogsmv3.global.security.data.ScheduleEnvironment;
-import team.themoment.sdk.exception.ExpectedException;
 
 @DisplayName("CreateMemberService 클래스의")
 class CreateMemberServiceTest {

--- a/src/test/java/team/themoment/hellogsmv3/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/member/service/MemberServiceTest.java
@@ -17,7 +17,7 @@ import org.springframework.http.HttpStatus;
 
 import team.themoment.hellogsmv3.domain.member.entity.Member;
 import team.themoment.hellogsmv3.domain.member.repository.MemberRepository;
-import team.themoment.sdk.exception.ExpectedException;
+import team.themoment.hellogsmv3.global.exception.error.ExpectedException;
 
 @DisplayName("MemberService 클래스의")
 public class MemberServiceTest {

--- a/src/test/java/team/themoment/hellogsmv3/domain/member/service/QueryMemberAuthInfoByIdServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/member/service/QueryMemberAuthInfoByIdServiceTest.java
@@ -19,7 +19,7 @@ import team.themoment.hellogsmv3.domain.member.entity.Member;
 import team.themoment.hellogsmv3.domain.member.entity.type.AuthReferrerType;
 import team.themoment.hellogsmv3.domain.member.entity.type.Role;
 import team.themoment.hellogsmv3.domain.member.repository.MemberRepository;
-import team.themoment.sdk.exception.ExpectedException;
+import team.themoment.hellogsmv3.global.exception.error.ExpectedException;
 
 @DisplayName("QueryMemberAuthInfoByIdService 클래스의")
 public class QueryMemberAuthInfoByIdServiceTest {

--- a/src/test/java/team/themoment/hellogsmv3/domain/member/service/QueryMemberByIdServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/member/service/QueryMemberByIdServiceTest.java
@@ -19,7 +19,7 @@ import team.themoment.hellogsmv3.domain.member.dto.response.FoundMemberResDto;
 import team.themoment.hellogsmv3.domain.member.entity.Member;
 import team.themoment.hellogsmv3.domain.member.entity.type.Sex;
 import team.themoment.hellogsmv3.domain.member.repository.MemberRepository;
-import team.themoment.sdk.exception.ExpectedException;
+import team.themoment.hellogsmv3.global.exception.error.ExpectedException;
 
 @DisplayName("QueryMemberByIdService 클래스의")
 class QueryMemberByIdServiceTest {

--- a/src/test/java/team/themoment/hellogsmv3/domain/member/service/impl/GenerateCodeServiceImplTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/member/service/impl/GenerateCodeServiceImplTest.java
@@ -18,7 +18,7 @@ import team.themoment.hellogsmv3.domain.member.dto.request.GenerateCodeReqDto;
 import team.themoment.hellogsmv3.domain.member.entity.AuthenticationCode;
 import team.themoment.hellogsmv3.domain.member.repository.CodeRepository;
 import team.themoment.hellogsmv3.domain.member.service.SendCodeNotificationService;
-import team.themoment.sdk.exception.ExpectedException;
+import team.themoment.hellogsmv3.global.exception.error.ExpectedException;
 
 @DisplayName("GenerateTestResultCodeServiceImpl 클래스의")
 class GenerateCodeServiceImplTest {

--- a/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/CreateOneseoServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/CreateOneseoServiceTest.java
@@ -35,9 +35,9 @@ import team.themoment.hellogsmv3.domain.oneseo.entity.type.GraduationType;
 import team.themoment.hellogsmv3.domain.oneseo.entity.type.Major;
 import team.themoment.hellogsmv3.domain.oneseo.entity.type.Screening;
 import team.themoment.hellogsmv3.domain.oneseo.repository.*;
+import team.themoment.hellogsmv3.global.exception.error.ExpectedException;
 import team.themoment.hellogsmv3.global.thirdParty.feign.client.dto.request.LambdaScoreCalculatorReqDto;
 import team.themoment.hellogsmv3.global.thirdParty.feign.client.lambda.LambdaScoreCalculatorClient;
-import team.themoment.sdk.exception.ExpectedException;
 
 @DisplayName("CreateOneseoService 클래스의")
 class CreateOneseoServiceTest {

--- a/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyCompetencyEvaluationScoreServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyCompetencyEvaluationScoreServiceTest.java
@@ -22,7 +22,7 @@ import team.themoment.hellogsmv3.domain.oneseo.dto.request.CompetencyEvaluationS
 import team.themoment.hellogsmv3.domain.oneseo.entity.EntranceTestResult;
 import team.themoment.hellogsmv3.domain.oneseo.entity.Oneseo;
 import team.themoment.hellogsmv3.domain.oneseo.repository.EntranceTestResultRepository;
-import team.themoment.sdk.exception.ExpectedException;
+import team.themoment.hellogsmv3.global.exception.error.ExpectedException;
 
 @DisplayName("ModifyCompetencyEvaluationScoreService 클래스의")
 public class ModifyCompetencyEvaluationScoreServiceTest {

--- a/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyEntranceIntentionServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyEntranceIntentionServiceTest.java
@@ -22,7 +22,7 @@ import team.themoment.hellogsmv3.domain.oneseo.entity.Oneseo;
 import team.themoment.hellogsmv3.domain.oneseo.entity.type.Major;
 import team.themoment.hellogsmv3.domain.oneseo.entity.type.YesNo;
 import team.themoment.hellogsmv3.domain.oneseo.repository.OneseoRepository;
-import team.themoment.sdk.exception.ExpectedException;
+import team.themoment.hellogsmv3.global.exception.error.ExpectedException;
 
 @DisplayName("ModifyEntranceIntentionService 클래스의")
 public class ModifyEntranceIntentionServiceTest {

--- a/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyInterviewScoreServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyInterviewScoreServiceTest.java
@@ -23,7 +23,7 @@ import team.themoment.hellogsmv3.domain.oneseo.dto.request.InterviewScoreReqDto;
 import team.themoment.hellogsmv3.domain.oneseo.entity.EntranceTestResult;
 import team.themoment.hellogsmv3.domain.oneseo.entity.Oneseo;
 import team.themoment.hellogsmv3.domain.oneseo.repository.EntranceTestResultRepository;
-import team.themoment.sdk.exception.ExpectedException;
+import team.themoment.hellogsmv3.global.exception.error.ExpectedException;
 
 @DisplayName("ModifyInterviewScoreService 클래스의")
 public class ModifyInterviewScoreServiceTest {

--- a/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyOneseoServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyOneseoServiceTest.java
@@ -36,9 +36,9 @@ import team.themoment.hellogsmv3.domain.oneseo.repository.MiddleSchoolAchievemen
 import team.themoment.hellogsmv3.domain.oneseo.repository.OneseoPrivacyDetailRepository;
 import team.themoment.hellogsmv3.domain.oneseo.repository.OneseoRepository;
 import team.themoment.hellogsmv3.domain.oneseo.repository.ScreeningChangeHistoryRepository;
+import team.themoment.hellogsmv3.global.exception.error.ExpectedException;
 import team.themoment.hellogsmv3.global.thirdParty.feign.client.dto.request.LambdaScoreCalculatorReqDto;
 import team.themoment.hellogsmv3.global.thirdParty.feign.client.lambda.LambdaScoreCalculatorClient;
-import team.themoment.sdk.exception.ExpectedException;
 
 @DisplayName("ModifyOneseoService 클래스의")
 class ModifyOneseoServiceTest {

--- a/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyRealOneseoArrivedYnServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyRealOneseoArrivedYnServiceTest.java
@@ -22,7 +22,7 @@ import team.themoment.hellogsmv3.domain.oneseo.entity.Oneseo;
 import team.themoment.hellogsmv3.domain.oneseo.entity.type.Screening;
 import team.themoment.hellogsmv3.domain.oneseo.entity.type.YesNo;
 import team.themoment.hellogsmv3.domain.oneseo.repository.OneseoRepository;
-import team.themoment.sdk.exception.ExpectedException;
+import team.themoment.hellogsmv3.global.exception.error.ExpectedException;
 
 @DisplayName("ModifyRealOneseoArrivedYnService 클래스의")
 public class ModifyRealOneseoArrivedYnServiceTest {

--- a/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/OneseoServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/OneseoServiceTest.java
@@ -30,7 +30,7 @@ import team.themoment.hellogsmv3.domain.oneseo.dto.request.OneseoReqDto;
 import team.themoment.hellogsmv3.domain.oneseo.entity.Oneseo;
 import team.themoment.hellogsmv3.domain.oneseo.entity.type.GraduationType;
 import team.themoment.hellogsmv3.domain.oneseo.repository.OneseoRepository;
-import team.themoment.sdk.exception.ExpectedException;
+import team.themoment.hellogsmv3.global.exception.error.ExpectedException;
 
 @DisplayName("OneseoService 클래스의")
 public class OneseoServiceTest {

--- a/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/OneseoTempStorageServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/OneseoTempStorageServiceTest.java
@@ -24,7 +24,7 @@ import team.themoment.hellogsmv3.domain.oneseo.dto.response.FoundOneseoResDto;
 import team.themoment.hellogsmv3.domain.oneseo.entity.type.GraduationType;
 import team.themoment.hellogsmv3.domain.oneseo.entity.type.Major;
 import team.themoment.hellogsmv3.domain.oneseo.repository.OneseoRepository;
-import team.themoment.sdk.exception.ExpectedException;
+import team.themoment.hellogsmv3.global.exception.error.ExpectedException;
 
 @DisplayName("OneseoTempStorageService 클래스의")
 public class OneseoTempStorageServiceTest {

--- a/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/QueryOneseoByIdServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/QueryOneseoByIdServiceTest.java
@@ -30,7 +30,7 @@ import team.themoment.hellogsmv3.domain.oneseo.entity.type.Major;
 import team.themoment.hellogsmv3.domain.oneseo.entity.type.Screening;
 import team.themoment.hellogsmv3.domain.oneseo.repository.MiddleSchoolAchievementRepository;
 import team.themoment.hellogsmv3.domain.oneseo.repository.OneseoPrivacyDetailRepository;
-import team.themoment.sdk.exception.ExpectedException;
+import team.themoment.hellogsmv3.global.exception.error.ExpectedException;
 
 @DisplayName("QueryOneseoByIdService 클래스의")
 class QueryOneseoByIdServiceTest {

--- a/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/UploadExcelServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/UploadExcelServiceTest.java
@@ -25,7 +25,7 @@ import org.springframework.web.multipart.MultipartFile;
 import team.themoment.hellogsmv3.domain.oneseo.entity.EntranceTestResult;
 import team.themoment.hellogsmv3.domain.oneseo.repository.EntranceTestResultRepository;
 import team.themoment.hellogsmv3.domain.oneseo.repository.OneseoRepository;
-import team.themoment.sdk.exception.ExpectedException;
+import team.themoment.hellogsmv3.global.exception.error.ExpectedException;
 
 @DisplayName("UploadExcelService 클래스의")
 class UploadExcelServiceTest {

--- a/src/test/java/team/themoment/hellogsmv3/domain/thirdParty/service/UploadImageServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/thirdParty/service/UploadImageServiceTest.java
@@ -22,10 +22,10 @@ import org.springframework.web.multipart.MultipartFile;
 import io.awspring.cloud.s3.ObjectMetadata;
 import io.awspring.cloud.s3.S3Resource;
 import io.awspring.cloud.s3.S3Template;
+import team.themoment.hellogsmv3.global.exception.error.ExpectedException;
 import team.themoment.hellogsmv3.global.thirdParty.aws.s3.data.S3Environment;
 import team.themoment.hellogsmv3.global.thirdParty.aws.s3.dto.response.UploadImageResDto;
 import team.themoment.hellogsmv3.global.thirdParty.aws.s3.service.UploadImageService;
-import team.themoment.sdk.exception.ExpectedException;
 
 @DisplayName("UploadImageService 클래스의")
 public class UploadImageServiceTest {


### PR DESCRIPTION
   ## 개요                                                                                                                                                        
                                   
  the-sdk 도입으로 대체되었던 로컬 구현체들을 복원하고, the-sdk 의존성 및 관련 설정을 전면 제거합니다.
                                     
  ## 본문                                 
                                          
  ### 제거 배경

  the-sdk에서 제공하는 클래스들이 프로젝트에 기존에 존재하던 클래스들과 충돌하여, 배포 시 빈(Bean) 중복 등록 문제가 발생했습니다.

  이를 해결하기 위해 한쪽을 제거하는 방향을 검토했으나, the-sdk의 클래스들이 기존 로컬 구현체의 역할을 완벽히 대체하지 못한다고 판단했습니다. 구체적으로 아래
  항목들이 SDK로 대체 불가능한 부분으로 확인되었습니다.

  - `LoggingFilter` — SDK 로깅의 제외 URL 패턴이 실제 프로젝트 경로(`/api-docs/**`, `/hello-management/prometheus/**`)와 불일치
  - `ApiResponseWrapper` — SDK 응답 래퍼가 `null` body → 204 처리, Spring 기본 에러 Map 변환 등 프로젝트 고유 동작을 지원하지 않음
  - `GlobalExceptionHandler` — SDK 예외 핸들러는 `ExpectedException`만 처리하며 나머지 예외 유형은 별도 핸들러가 필요

  따라서 일단 the-sdk를 제거하고, 도입 여부는 추후 다시 논의하기로 합니다.

  ### the-sdk 도입 커밋 구성

  - `fed80373`: build.gradle에 SDK 의존성/JitPack 저장소 추가, application.yml에 sdk: 설정 추가
  - `846df42a`: 로컬 구현체 삭제 후 SDK 클래스로 대체 및 전체 import 전환

  이번 PR은 위 두 커밋의 변경사항을 모두 되돌려 the-sdk 도입 이전 상태로 복원합니다.

  ### 추가

  - `LoggingFilter` — HTTP 요청/응답 로깅 필터 (Log-ID, IP, URI, Body 등 로깅)
  - `CachedBodyRequestWrapper` — 요청 바디 재사용을 위한 InputStream 캐싱 래퍼
  - `CommonApiResponse` — 공통 API 응답 래퍼 클래스 (로컬 구현체)
  - `ExpectedException` — 비즈니스 예외 처리용 커스텀 예외 클래스 (로컬 구현체)

  ### 변경

  - `build.gradle` — the-sdk 의존성 및 JitPack 저장소 제거
  - `application.yml` — sdk: 설정 블록 전체 제거
  - `GlobalExceptionHandler` — ExpectedException 핸들러 재추가
  - 전체 서비스/컨트롤러/테스트 — import를 SDK 클래스에서 로컬 클래스로 복원


---

# RCA 룰

r: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)  
c: 웬만하면 반영해 주세요. (Comment)  
a: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)
