### PR TITLE
[oneseo] 원서 제출 후 어드민에게 수정 권한을 요청할 수 있는 기능 구현

### DIFF
--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/controller/OneseoController.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/controller/OneseoController.java
@@ -39,6 +39,7 @@ public class OneseoController {
 
     private final CreateOneseoService createOneseoService;
     private final ModifyOneseoService modifyOneseoService;
+    private final ModifyOneseoByApplicantService modifyOneseoByApplicantService;
     private final ModifyRealOneseoArrivedYnService modifyRealOneseoArrivedYnService;
     private final ModifyCompetencyEvaluationScoreService modifyCompetencyEvaluationScoreService;
     private final ModifyInterviewScoreService modifyInterviewScoreService;
@@ -50,6 +51,8 @@ public class OneseoController {
     private final ModifyEntranceIntentionService modifyEntranceIntentionService;
     private final QueryOneseoEditabilityService queryOneseoEditabilityService;
     private final UploadExcelService uploadExcelService;
+    private final RequestOneseoEditPermissionService requestOneseoEditPermissionService;
+    private final ApproveOneseoEditPermissionService approveOneseoEditPermissionService;
 
     @Operation(summary = "내 원서 등록", description = "원서를 등록합니다.")
     @PostMapping("/oneseo/me")
@@ -157,9 +160,30 @@ public class OneseoController {
         return CommonApiResponse.success("수정되었습니다.");
     }
 
-    @Operation(summary = "원서 수정 가능여부", description = "원서 수정이 가능한지에 대해 반환합니다.")
+    @Operation(summary = "원서 수정 가능여부", description = "원서 수정이 가능한지에 대해 반환합니다. 지원자는 본인의 수정 권한 상태도 함께 반환합니다.")
     @GetMapping("/editability")
-    public OneseoEditabilityResDto getOneseoEditability() {
-        return queryOneseoEditabilityService.execute();
+    public OneseoEditabilityResDto getOneseoEditability(@AuthRequest Long memberId) {
+        return queryOneseoEditabilityService.execute(memberId);
+    }
+
+    @Operation(summary = "원서 수정 권한 요청", description = "지원자가 원서 수정 권한을 요청합니다.")
+    @PostMapping("/oneseo/me/request")
+    public CommonApiResponse requestEditPermission(@AuthRequest Long memberId) {
+        requestOneseoEditPermissionService.execute(memberId);
+        return CommonApiResponse.success("원서 수정 권한 요청이 완료되었습니다.");
+    }
+
+    @Operation(summary = "원서 수정 권한 승인", description = "관리자가 원서 수정 권한을 승인합니다.")
+    @PatchMapping("/oneseo/{memberId}/approval")
+    public CommonApiResponse approveEditPermission(@PathVariable Long memberId) {
+        approveOneseoEditPermissionService.execute(memberId);
+        return CommonApiResponse.success("수정되었습니다.");
+    }
+
+    @Operation(summary = "내 원서 수정 (지원자)", description = "수정 권한이 승인된 지원자가 원서를 수정합니다.")
+    @PutMapping("/oneseo/me")
+    public CommonApiResponse modifyByApplicant(@RequestBody @Valid OneseoReqDto reqDto, @AuthRequest Long memberId) {
+        modifyOneseoByApplicantService.execute(reqDto, memberId);
+        return CommonApiResponse.success("수정되었습니다.");
     }
 }

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/controller/OneseoController.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/controller/OneseoController.java
@@ -58,7 +58,7 @@ public class OneseoController {
     @PostMapping("/oneseo/me")
     public CommonApiResponse create(@RequestBody @Valid OneseoReqDto reqDto, @AuthRequest Long memberId) {
         createOneseoService.execute(reqDto, memberId);
-        return CommonApiResponse.created("생성되었습니다.");
+        return CommonApiResponse.created("원서가 생성되었습니다.");
     }
 
     @Operation(summary = "원서 수정", description = "맴버 id로 원서를 수정합니다.")
@@ -66,7 +66,7 @@ public class OneseoController {
     public CommonApiResponse modifyByAdmin(@RequestBody @Valid OneseoReqDto reqDto,
             @PathVariable("memberId") Long memberId) {
         modifyOneseoService.execute(reqDto, memberId);
-        return CommonApiResponse.success("수정되었습니다.");
+        return CommonApiResponse.success("원서가 수정되었습니다.");
     }
 
     @Operation(summary = "실물 원서 제출 여부 수정", description = "맴버 id로 원서의 실물 원서 제출 여부를 수정합니다.")
@@ -126,7 +126,7 @@ public class OneseoController {
             @RequestParam Integer step,
             @AuthRequest Long memberId) {
         oneseoTempStorageService.execute(reqDto, step, memberId);
-        return CommonApiResponse.success("임시저장되었습니다.");
+        return CommonApiResponse.success("원서가 임시저장되었습니다.");
     }
 
     @Operation(summary = "엑셀 업로드", description = "엑셀 파일을 업로드하여 2차전형 점수를 입력합니다.")
@@ -177,13 +177,13 @@ public class OneseoController {
     @PatchMapping("/oneseo/{memberId}/approval")
     public CommonApiResponse approveEditPermission(@PathVariable Long memberId) {
         approveOneseoEditPermissionService.execute(memberId);
-        return CommonApiResponse.success("수정되었습니다.");
+        return CommonApiResponse.success("원서 수정 권한 요청이 승인되었습니다.");
     }
 
     @Operation(summary = "내 원서 수정 (지원자)", description = "수정 권한이 승인된 지원자가 원서를 수정합니다.")
     @PutMapping("/oneseo/me")
     public CommonApiResponse modifyByApplicant(@RequestBody @Valid OneseoReqDto reqDto, @AuthRequest Long memberId) {
         modifyOneseoByApplicantService.execute(reqDto, memberId);
-        return CommonApiResponse.success("수정되었습니다.");
+        return CommonApiResponse.success("원서가 수정되었습니다.");
     }
 }

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/dto/response/OneseoEditabilityResDto.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/dto/response/OneseoEditabilityResDto.java
@@ -1,4 +1,6 @@
 package team.themoment.hellogsmv3.domain.oneseo.dto.response;
 
-public record OneseoEditabilityResDto(Boolean oneseoEditability) {
+import team.themoment.hellogsmv3.domain.oneseo.entity.type.OneseoEditStatus;
+
+public record OneseoEditabilityResDto(Boolean oneseoEditability, OneseoEditStatus oneseoEditStatus) {
 }

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/dto/response/SearchOneseoResDto.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/dto/response/SearchOneseoResDto.java
@@ -3,6 +3,7 @@ package team.themoment.hellogsmv3.domain.oneseo.dto.response;
 import java.math.BigDecimal;
 
 import lombok.Builder;
+import team.themoment.hellogsmv3.domain.oneseo.entity.type.OneseoEditStatus;
 import team.themoment.hellogsmv3.domain.oneseo.entity.type.Screening;
 import team.themoment.hellogsmv3.domain.oneseo.entity.type.YesNo;
 
@@ -11,5 +12,5 @@ public record SearchOneseoResDto(Long memberId, String submitCode, YesNo realOne
         Screening screening, String schoolName, String phoneNumber, String guardianPhoneNumber,
         String schoolTeacherPhoneNumber, String examinationNumber, YesNo firstTestPassYn,
         BigDecimal competencyEvaluationScore, BigDecimal interviewScore, YesNo secondTestPassYn,
-        YesNo entranceIntentionYn) {
+        YesNo entranceIntentionYn, OneseoEditStatus oneseoEditStatus) {
 }

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/entity/Oneseo.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/entity/Oneseo.java
@@ -13,6 +13,7 @@ import lombok.*;
 import team.themoment.hellogsmv3.domain.member.entity.Member;
 import team.themoment.hellogsmv3.domain.oneseo.entity.type.DesiredMajors;
 import team.themoment.hellogsmv3.domain.oneseo.entity.type.Major;
+import team.themoment.hellogsmv3.domain.oneseo.entity.type.OneseoEditStatus;
 import team.themoment.hellogsmv3.domain.oneseo.entity.type.Screening;
 import team.themoment.hellogsmv3.domain.oneseo.entity.type.YesNo;
 
@@ -83,6 +84,11 @@ public class Oneseo {
     @Column(name = "decided_major")
     private Major decidedMajor;
 
+    @Builder.Default
+    @Enumerated(EnumType.STRING)
+    @Column(name = "oneseo_edit_status", nullable = false)
+    private OneseoEditStatus oneseoEditStatus = OneseoEditStatus.NONE;
+
     public void addWantedScreeningChangeHistory(WantedScreeningChangeHistory wantedScreeningChangeHistory) {
         this.wantedScreeningChangeHistory.add(wantedScreeningChangeHistory);
     }
@@ -111,5 +117,17 @@ public class Oneseo {
 
     public void switchRealOneseoArrivedYn() {
         this.realOneseoArrivedYn = this.realOneseoArrivedYn == YES ? NO : YES;
+    }
+
+    public void requestEditPermit() {
+        this.oneseoEditStatus = OneseoEditStatus.REQUESTED;
+    }
+
+    public void approveEditPermit() {
+        this.oneseoEditStatus = OneseoEditStatus.APPROVED;
+    }
+
+    public void revokeEditPermit() {
+        this.oneseoEditStatus = OneseoEditStatus.NONE;
     }
 }

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/entity/type/OneseoEditStatus.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/entity/type/OneseoEditStatus.java
@@ -1,0 +1,5 @@
+package team.themoment.hellogsmv3.domain.oneseo.entity.type;
+
+public enum OneseoEditStatus {
+    NONE, REQUESTED, APPROVED
+}

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/repository/custom/impl/CustomOneseoRepositoryImpl.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/repository/custom/impl/CustomOneseoRepositoryImpl.java
@@ -89,7 +89,8 @@ public class CustomOneseoRepositoryImpl implements CustomOneseoRepository {
                         oneseo.entranceTestResult.competencyEvaluationScore,
                         oneseo.entranceTestResult.interviewScore,
                         oneseo.entranceTestResult.secondTestPassYn,
-                        oneseo.entranceIntentionYn))
+                        oneseo.entranceIntentionYn,
+                        oneseo.oneseoEditStatus))
                 .from(oneseo).join(oneseo.member, member).join(oneseo.oneseoPrivacyDetail, oneseoPrivacyDetail)
                 .join(oneseo.entranceTestResult, entranceTestResult).where(builder)
                 .orderBy(oneseo.oneseoSubmitCode.desc()).offset(pageable.getOffset()).limit(pageable.getPageSize())
@@ -209,4 +210,5 @@ public class CustomOneseoRepositoryImpl implements CustomOneseoRepository {
 
         return new FoundMemberAndOneseoDto(result.get(member), result.get(oneseo));
     }
+
 }

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/ApproveOneseoEditPermissionService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/ApproveOneseoEditPermissionService.java
@@ -1,0 +1,31 @@
+package team.themoment.hellogsmv3.domain.oneseo.service;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+import team.themoment.hellogsmv3.domain.oneseo.entity.Oneseo;
+import team.themoment.hellogsmv3.domain.oneseo.entity.type.OneseoEditStatus;
+import team.themoment.hellogsmv3.domain.oneseo.repository.OneseoRepository;
+import team.themoment.sdk.exception.ExpectedException;
+
+@Service
+@RequiredArgsConstructor
+public class ApproveOneseoEditPermissionService {
+
+    private final OneseoService oneseoService;
+    private final OneseoRepository oneseoRepository;
+
+    @Transactional
+    public void execute(Long memberId) {
+        Oneseo oneseo = oneseoService.findWithMemberByMemberIdOrThrow(memberId);
+
+        if (oneseo.getOneseoEditStatus() != OneseoEditStatus.REQUESTED) {
+            throw new ExpectedException("원서 수정 권한 요청이 존재하지 않습니다.", HttpStatus.BAD_REQUEST);
+        }
+
+        oneseo.approveEditPermit();
+        oneseoRepository.save(oneseo);
+    }
+}

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/ApproveOneseoEditPermissionService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/ApproveOneseoEditPermissionService.java
@@ -7,7 +7,6 @@ import org.springframework.transaction.annotation.Transactional;
 import lombok.RequiredArgsConstructor;
 import team.themoment.hellogsmv3.domain.oneseo.entity.Oneseo;
 import team.themoment.hellogsmv3.domain.oneseo.entity.type.OneseoEditStatus;
-import team.themoment.hellogsmv3.domain.oneseo.repository.OneseoRepository;
 import team.themoment.sdk.exception.ExpectedException;
 
 @Service
@@ -15,7 +14,6 @@ import team.themoment.sdk.exception.ExpectedException;
 public class ApproveOneseoEditPermissionService {
 
     private final OneseoService oneseoService;
-    private final OneseoRepository oneseoRepository;
 
     @Transactional
     public void execute(Long memberId) {
@@ -26,6 +24,5 @@ public class ApproveOneseoEditPermissionService {
         }
 
         oneseo.approveEditPermit();
-        oneseoRepository.save(oneseo);
     }
 }

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyOneseoByApplicantService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyOneseoByApplicantService.java
@@ -1,0 +1,36 @@
+package team.themoment.hellogsmv3.domain.oneseo.service;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+import team.themoment.hellogsmv3.domain.oneseo.dto.request.OneseoReqDto;
+import team.themoment.hellogsmv3.domain.oneseo.entity.Oneseo;
+import team.themoment.hellogsmv3.domain.oneseo.entity.type.OneseoEditStatus;
+import team.themoment.hellogsmv3.domain.oneseo.repository.OneseoRepository;
+import team.themoment.sdk.exception.ExpectedException;
+
+@Service
+@RequiredArgsConstructor
+public class ModifyOneseoByApplicantService {
+
+    private final OneseoService oneseoService;
+    private final OneseoRepository oneseoRepository;
+    private final ModifyOneseoService modifyOneseoService;
+
+    @Transactional
+    public void execute(OneseoReqDto reqDto, Long memberId) {
+        Oneseo oneseo = oneseoService.findWithMemberByMemberIdOrThrow(memberId);
+
+        if (oneseo.getOneseoEditStatus() != OneseoEditStatus.APPROVED) {
+            throw new ExpectedException("원서 수정 권한이 없습니다.", HttpStatus.FORBIDDEN);
+        }
+
+        modifyOneseoService.execute(reqDto, memberId);
+
+        Oneseo saved = oneseoService.findWithMemberByMemberIdOrThrow(memberId);
+        saved.revokeEditPermit();
+        oneseoRepository.save(saved);
+    }
+}

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyOneseoByApplicantService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyOneseoByApplicantService.java
@@ -26,8 +26,5 @@ public class ModifyOneseoByApplicantService {
         }
 
         modifyOneseoService.execute(reqDto, memberId);
-
-        Oneseo saved = oneseoService.findWithMemberByMemberIdOrThrow(memberId);
-        saved.revokeEditPermit();
     }
 }

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyOneseoByApplicantService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyOneseoByApplicantService.java
@@ -8,7 +8,6 @@ import lombok.RequiredArgsConstructor;
 import team.themoment.hellogsmv3.domain.oneseo.dto.request.OneseoReqDto;
 import team.themoment.hellogsmv3.domain.oneseo.entity.Oneseo;
 import team.themoment.hellogsmv3.domain.oneseo.entity.type.OneseoEditStatus;
-import team.themoment.hellogsmv3.domain.oneseo.repository.OneseoRepository;
 import team.themoment.sdk.exception.ExpectedException;
 
 @Service
@@ -16,7 +15,6 @@ import team.themoment.sdk.exception.ExpectedException;
 public class ModifyOneseoByApplicantService {
 
     private final OneseoService oneseoService;
-    private final OneseoRepository oneseoRepository;
     private final ModifyOneseoService modifyOneseoService;
 
     @Transactional
@@ -31,6 +29,5 @@ public class ModifyOneseoByApplicantService {
 
         Oneseo saved = oneseoService.findWithMemberByMemberIdOrThrow(memberId);
         saved.revokeEditPermit();
-        oneseoRepository.save(saved);
     }
 }

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyOneseoService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyOneseoService.java
@@ -240,7 +240,7 @@ public class ModifyOneseoService {
                 .realOneseoArrivedYn(oneseo.getRealOneseoArrivedYn()).wantedScreening(reqDto.screening())
                 .passYn(oneseo.getPassYn()).decidedMajor(oneseo.getDecidedMajor())
                 .entranceIntentionYn(oneseo.getEntranceIntentionYn()).oneseoSubmitCode(oneseo.getOneseoSubmitCode())
-                .build();
+                .oneseoEditStatus(oneseo.getOneseoEditStatus()).build();
     }
 
     private void saveOneseoPrivacyDetail(OneseoReqDto reqDto, OneseoPrivacyDetail oneseoPrivacyDetail, Oneseo oneseo) {

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyOneseoService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyOneseoService.java
@@ -61,6 +61,7 @@ public class ModifyOneseoService {
         saveMiddleSchoolAchievement(reqDto, middleSchoolAchievement, modifiedOneseo);
         saveHistoryIfWantedScreeningChange(reqDto.screening(), currentOneseo.getWantedScreening(), modifiedOneseo);
 
+        modifiedOneseo.revokeEditPermit();
         oneseoRepository.save(modifiedOneseo);
 
         CalculatedScoreResDto calculatedScoreResDto = calculateMiddleSchoolAchievement(reqDto.graduationType(),

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/QueryOneseoEditabilityService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/QueryOneseoEditabilityService.java
@@ -4,18 +4,25 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
+import team.themoment.hellogsmv3.domain.oneseo.dto.internal.FoundMemberAndOneseoDto;
 import team.themoment.hellogsmv3.domain.oneseo.dto.response.OneseoEditabilityResDto;
 import team.themoment.hellogsmv3.domain.oneseo.repository.EntranceTestResultRepository;
+import team.themoment.hellogsmv3.domain.oneseo.repository.OneseoRepository;
 
 @Service
 @RequiredArgsConstructor
 public class QueryOneseoEditabilityService {
 
     private final EntranceTestResultRepository entranceTestResultRepository;
+    private final OneseoRepository oneseoRepository;
 
     @Transactional(readOnly = true)
-    public OneseoEditabilityResDto execute() {
+    public OneseoEditabilityResDto execute(Long memberId) {
         boolean isFirstTestFinished = entranceTestResultRepository.existsByFirstTestPassYnIsNotNull();
-        return new OneseoEditabilityResDto(!isFirstTestFinished);
+        FoundMemberAndOneseoDto queryResult = oneseoRepository.findMemberAndOneseoByMemberId(memberId);
+        if (queryResult.oneseo() == null) {
+            return new OneseoEditabilityResDto(!isFirstTestFinished, null);
+        }
+        return new OneseoEditabilityResDto(!isFirstTestFinished, queryResult.oneseo().getOneseoEditStatus());
     }
 }

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/RequestOneseoEditPermissionService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/RequestOneseoEditPermissionService.java
@@ -9,7 +9,6 @@ import org.springframework.transaction.annotation.Transactional;
 import lombok.RequiredArgsConstructor;
 import team.themoment.hellogsmv3.domain.oneseo.entity.Oneseo;
 import team.themoment.hellogsmv3.domain.oneseo.entity.type.OneseoEditStatus;
-import team.themoment.hellogsmv3.domain.oneseo.repository.OneseoRepository;
 import team.themoment.sdk.exception.ExpectedException;
 
 @Service
@@ -20,7 +19,6 @@ public class RequestOneseoEditPermissionService {
     private static final LocalTime REQUEST_END = LocalTime.of(16, 0);
 
     private final OneseoService oneseoService;
-    private final OneseoRepository oneseoRepository;
 
     @Transactional
     public void execute(Long memberId) {
@@ -41,6 +39,5 @@ public class RequestOneseoEditPermissionService {
         }
 
         oneseo.requestEditPermit();
-        oneseoRepository.save(oneseo);
     }
 }

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/RequestOneseoEditPermissionService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/RequestOneseoEditPermissionService.java
@@ -20,9 +20,13 @@ public class RequestOneseoEditPermissionService {
 
     private final OneseoService oneseoService;
 
+    protected LocalTime getCurrentTime() {
+        return LocalTime.now();
+    }
+
     @Transactional
     public void execute(Long memberId) {
-        LocalTime now = LocalTime.now();
+        LocalTime now = getCurrentTime();
         if (now.isBefore(REQUEST_START) || now.isAfter(REQUEST_END)) {
             throw new ExpectedException("원서 수정 권한 요청은 09:00 ~ 16:00 사이에만 가능합니다.", HttpStatus.FORBIDDEN);
         }

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/RequestOneseoEditPermissionService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/RequestOneseoEditPermissionService.java
@@ -1,0 +1,46 @@
+package team.themoment.hellogsmv3.domain.oneseo.service;
+
+import java.time.LocalTime;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+import team.themoment.hellogsmv3.domain.oneseo.entity.Oneseo;
+import team.themoment.hellogsmv3.domain.oneseo.entity.type.OneseoEditStatus;
+import team.themoment.hellogsmv3.domain.oneseo.repository.OneseoRepository;
+import team.themoment.sdk.exception.ExpectedException;
+
+@Service
+@RequiredArgsConstructor
+public class RequestOneseoEditPermissionService {
+
+    private static final LocalTime REQUEST_START = LocalTime.of(9, 0);
+    private static final LocalTime REQUEST_END = LocalTime.of(16, 0);
+
+    private final OneseoService oneseoService;
+    private final OneseoRepository oneseoRepository;
+
+    @Transactional
+    public void execute(Long memberId) {
+        LocalTime now = LocalTime.now();
+        if (now.isBefore(REQUEST_START) || now.isAfter(REQUEST_END)) {
+            throw new ExpectedException("원서 수정 권한 요청은 09:00 ~ 16:00 사이에만 가능합니다.", HttpStatus.FORBIDDEN);
+        }
+
+        Oneseo oneseo = oneseoService.findWithMemberByMemberIdOrThrow(memberId);
+
+        OneseoService.isBeforeFirstTest(oneseo.getEntranceTestResult().getFirstTestPassYn());
+
+        if (oneseo.getOneseoEditStatus() == OneseoEditStatus.APPROVED) {
+            throw new ExpectedException("이미 원서 수정 권한이 부여된 상태입니다.", HttpStatus.CONFLICT);
+        }
+        if (oneseo.getOneseoEditStatus() == OneseoEditStatus.REQUESTED) {
+            throw new ExpectedException("이미 원서 수정 권한 요청이 진행 중입니다.", HttpStatus.CONFLICT);
+        }
+
+        oneseo.requestEditPermit();
+        oneseoRepository.save(oneseo);
+    }
+}

--- a/src/main/java/team/themoment/hellogsmv3/global/security/SecurityConfig.java
+++ b/src/main/java/team/themoment/hellogsmv3/global/security/SecurityConfig.java
@@ -49,7 +49,6 @@ public class SecurityConfig {
         LocalDateTime oneseoSubmissionEnd = scheduleEnv.oneseoSubmissionEnd();
         LocalDateTime interview = scheduleEnv.interview();
         LocalDateTime finalResultsAnnouncement = scheduleEnv.finalResultsAnnouncement();
-
         return new TimeBasedFilter()
                 .addFilter(HttpMethod.POST, "/oneseo/v3/temp-storage", oneseoSubmissionStart, oneseoSubmissionEnd)
                 .addFilter(HttpMethod.POST, "/oneseo/v3/oneseo/me", oneseoSubmissionStart, oneseoSubmissionEnd)
@@ -163,7 +162,10 @@ public class SecurityConfig {
                 .requestMatchers(HttpMethod.POST, "/oneseo/v3/excel").hasAnyAuthority(ADMIN_ONLY)
                 .requestMatchers(HttpMethod.GET, "/oneseo/v3/excel").hasAnyAuthority(ADMIN_ONLY)
                 .requestMatchers(HttpMethod.GET, "/oneseo/v3/admission-tickets").hasAnyAuthority(ADMIN_ONLY)
-                .requestMatchers(HttpMethod.GET, "/oneseo/v3/editability").hasAnyAuthority(ADMIN_ONLY);
+                .requestMatchers(HttpMethod.GET, "/oneseo/v3/editability").hasAnyAuthority(ALL_AUTHENTICATED)
+                .requestMatchers(HttpMethod.POST, "/oneseo/v3/oneseo/me/request").hasAnyAuthority(APPLICANT_OR_ROOT)
+                .requestMatchers(HttpMethod.PATCH, "/oneseo/v3/oneseo/{memberId}/approval").hasAnyAuthority(ADMIN_ONLY)
+                .requestMatchers(HttpMethod.PUT, "/oneseo/v3/oneseo/me").hasAnyAuthority(APPLICANT_OR_ROOT);
     }
 
     private void operationRequests(

--- a/src/main/java/team/themoment/hellogsmv3/global/security/SecurityConfig.java
+++ b/src/main/java/team/themoment/hellogsmv3/global/security/SecurityConfig.java
@@ -156,7 +156,6 @@ public class SecurityConfig {
                 .requestMatchers(HttpMethod.PATCH, "/oneseo/v3/interview-score/{memberId}").hasAnyAuthority(ADMIN_ONLY)
                 .requestMatchers(HttpMethod.POST, "/oneseo/v3/image")
                 .hasAnyAuthority(Role.APPLICANT.name(), Role.ADMIN.name(), Role.ROOT.name())
-                .requestMatchers(HttpMethod.DELETE, "/oneseo/v3/oneseo/me").hasAnyAuthority(APPLICANT_OR_ROOT)
                 .requestMatchers(HttpMethod.GET, "/oneseo/v3/oneseo/search").hasAnyAuthority(ADMIN_ONLY)
                 .requestMatchers(HttpMethod.PUT, "/oneseo/v3/final-submit").hasAnyAuthority(Role.APPLICANT.name())
                 .requestMatchers(HttpMethod.POST, "/oneseo/v3/excel").hasAnyAuthority(ADMIN_ONLY)
@@ -164,8 +163,7 @@ public class SecurityConfig {
                 .requestMatchers(HttpMethod.GET, "/oneseo/v3/admission-tickets").hasAnyAuthority(ADMIN_ONLY)
                 .requestMatchers(HttpMethod.GET, "/oneseo/v3/editability").hasAnyAuthority(ALL_AUTHENTICATED)
                 .requestMatchers(HttpMethod.POST, "/oneseo/v3/oneseo/me/request").hasAnyAuthority(APPLICANT_OR_ROOT)
-                .requestMatchers(HttpMethod.PATCH, "/oneseo/v3/oneseo/{memberId}/approval").hasAnyAuthority(ADMIN_ONLY)
-                .requestMatchers(HttpMethod.PUT, "/oneseo/v3/oneseo/me").hasAnyAuthority(APPLICANT_OR_ROOT);
+                .requestMatchers(HttpMethod.PATCH, "/oneseo/v3/oneseo/{memberId}/approval").hasAnyAuthority(ADMIN_ONLY);
     }
 
     private void operationRequests(

--- a/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/ApproveOneseoEditPermissionServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/ApproveOneseoEditPermissionServiceTest.java
@@ -1,0 +1,89 @@
+package team.themoment.hellogsmv3.domain.oneseo.service;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.http.HttpStatus;
+
+import team.themoment.hellogsmv3.domain.oneseo.entity.Oneseo;
+import team.themoment.hellogsmv3.domain.oneseo.entity.type.OneseoEditStatus;
+import team.themoment.sdk.exception.ExpectedException;
+
+@DisplayName("ApproveOneseoEditPermissionService 클래스의")
+class ApproveOneseoEditPermissionServiceTest {
+
+    @Mock
+    private OneseoService oneseoService;
+
+    @InjectMocks
+    private ApproveOneseoEditPermissionService service;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Nested
+    @DisplayName("execute 메서드는")
+    class Describe_execute {
+
+        private final Long memberId = 1L;
+        private Oneseo oneseo;
+
+        @BeforeEach
+        void setUp() {
+            oneseo = mock(Oneseo.class);
+            given(oneseoService.findWithMemberByMemberIdOrThrow(memberId)).willReturn(oneseo);
+        }
+
+        @Nested
+        @DisplayName("REQUESTED 상태가 아닌 경우")
+        class Context_when_not_requested {
+
+            @Test
+            @DisplayName("NONE 상태이면 BAD_REQUEST ExpectedException을 던진다")
+            void it_throws_bad_request_when_none() {
+                given(oneseo.getOneseoEditStatus()).willReturn(OneseoEditStatus.NONE);
+
+                ExpectedException ex = assertThrows(ExpectedException.class, () -> service.execute(memberId));
+                assert ex.getStatusCode() == HttpStatus.BAD_REQUEST;
+            }
+
+            @Test
+            @DisplayName("APPROVED 상태이면 BAD_REQUEST ExpectedException을 던진다")
+            void it_throws_bad_request_when_approved() {
+                given(oneseo.getOneseoEditStatus()).willReturn(OneseoEditStatus.APPROVED);
+
+                ExpectedException ex = assertThrows(ExpectedException.class, () -> service.execute(memberId));
+                assert ex.getStatusCode() == HttpStatus.BAD_REQUEST;
+            }
+        }
+
+        @Nested
+        @DisplayName("REQUESTED 상태인 경우")
+        class Context_when_requested {
+
+            @BeforeEach
+            void setUp() {
+                given(oneseo.getOneseoEditStatus()).willReturn(OneseoEditStatus.REQUESTED);
+            }
+
+            @Test
+            @DisplayName("approveEditPermit을 호출한다")
+            void it_calls_approve_edit_permit() {
+                assertDoesNotThrow(() -> service.execute(memberId));
+                verify(oneseo).approveEditPermit();
+            }
+        }
+    }
+}

--- a/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyOneseoByApplicantServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyOneseoByApplicantServiceTest.java
@@ -1,0 +1,95 @@
+package team.themoment.hellogsmv3.domain.oneseo.service;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.http.HttpStatus;
+
+import team.themoment.hellogsmv3.domain.oneseo.dto.request.OneseoReqDto;
+import team.themoment.hellogsmv3.domain.oneseo.entity.Oneseo;
+import team.themoment.hellogsmv3.domain.oneseo.entity.type.OneseoEditStatus;
+import team.themoment.sdk.exception.ExpectedException;
+
+@DisplayName("ModifyOneseoByApplicantService 클래스의")
+class ModifyOneseoByApplicantServiceTest {
+
+    @Mock
+    private OneseoService oneseoService;
+
+    @Mock
+    private ModifyOneseoService modifyOneseoService;
+
+    @InjectMocks
+    private ModifyOneseoByApplicantService service;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Nested
+    @DisplayName("execute 메서드는")
+    class Describe_execute {
+
+        private final Long memberId = 1L;
+        private OneseoReqDto reqDto;
+        private Oneseo oneseo;
+
+        @BeforeEach
+        void setUp() {
+            reqDto = mock(OneseoReqDto.class);
+            oneseo = mock(Oneseo.class);
+            given(oneseoService.findWithMemberByMemberIdOrThrow(memberId)).willReturn(oneseo);
+        }
+
+        @Nested
+        @DisplayName("APPROVED 상태가 아닌 경우")
+        class Context_when_not_approved {
+
+            @Test
+            @DisplayName("NONE 상태이면 FORBIDDEN ExpectedException을 던진다")
+            void it_throws_forbidden_when_none() {
+                given(oneseo.getOneseoEditStatus()).willReturn(OneseoEditStatus.NONE);
+
+                ExpectedException ex = assertThrows(ExpectedException.class, () -> service.execute(reqDto, memberId));
+                assert ex.getStatusCode() == HttpStatus.FORBIDDEN;
+            }
+
+            @Test
+            @DisplayName("REQUESTED 상태이면 FORBIDDEN ExpectedException을 던진다")
+            void it_throws_forbidden_when_requested() {
+                given(oneseo.getOneseoEditStatus()).willReturn(OneseoEditStatus.REQUESTED);
+
+                ExpectedException ex = assertThrows(ExpectedException.class, () -> service.execute(reqDto, memberId));
+                assert ex.getStatusCode() == HttpStatus.FORBIDDEN;
+            }
+        }
+
+        @Nested
+        @DisplayName("APPROVED 상태인 경우")
+        class Context_when_approved {
+
+            @BeforeEach
+            void setUp() {
+                given(oneseo.getOneseoEditStatus()).willReturn(OneseoEditStatus.APPROVED);
+            }
+
+            @Test
+            @DisplayName("modifyOneseoService.execute를 호출한다")
+            void it_calls_modify_oneseo_service() {
+                assertDoesNotThrow(() -> service.execute(reqDto, memberId));
+                verify(modifyOneseoService).execute(reqDto, memberId);
+            }
+        }
+    }
+}

--- a/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/QueryOneseoEditabilityServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/QueryOneseoEditabilityServiceTest.java
@@ -1,7 +1,9 @@
 package team.themoment.hellogsmv3.domain.oneseo.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -11,14 +13,21 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
+import team.themoment.hellogsmv3.domain.oneseo.dto.internal.FoundMemberAndOneseoDto;
 import team.themoment.hellogsmv3.domain.oneseo.dto.response.OneseoEditabilityResDto;
+import team.themoment.hellogsmv3.domain.oneseo.entity.Oneseo;
+import team.themoment.hellogsmv3.domain.oneseo.entity.type.OneseoEditStatus;
 import team.themoment.hellogsmv3.domain.oneseo.repository.EntranceTestResultRepository;
+import team.themoment.hellogsmv3.domain.oneseo.repository.OneseoRepository;
 
 @DisplayName("QueryOneseoEditabilityService 클래스의")
 class QueryOneseoEditabilityServiceTest {
 
     @Mock
     private EntranceTestResultRepository entranceTestResultRepository;
+
+    @Mock
+    private OneseoRepository oneseoRepository;
 
     @InjectMocks
     private QueryOneseoEditabilityService queryOneseoEditabilityService;
@@ -41,11 +50,44 @@ class QueryOneseoEditabilityServiceTest {
                 given(entranceTestResultRepository.existsByFirstTestPassYnIsNotNull()).willReturn(false);
             }
 
-            @Test
-            @DisplayName("수정 가능 여부가 true인 OneseoEditabilityResDto를 반환한다")
-            void it_returns_true_editability() {
-                OneseoEditabilityResDto result = queryOneseoEditabilityService.execute();
-                assertEquals(true, result.oneseoEditability());
+            @Nested
+            @DisplayName("원서가 존재하는 경우")
+            class Context_with_existing_oneseo {
+
+                @BeforeEach
+                void setUp() {
+                    Oneseo oneseo = mock(Oneseo.class);
+                    given(oneseo.getOneseoEditStatus()).willReturn(OneseoEditStatus.NONE);
+                    given(oneseoRepository.findMemberAndOneseoByMemberId(1L))
+                            .willReturn(new FoundMemberAndOneseoDto(null, oneseo));
+                }
+
+                @Test
+                @DisplayName("수정 가능 여부가 true이고 oneseoEditStatus를 반환한다")
+                void it_returns_true_editability_with_edit_status() {
+                    OneseoEditabilityResDto result = queryOneseoEditabilityService.execute(1L);
+                    assertEquals(true, result.oneseoEditability());
+                    assertEquals(OneseoEditStatus.NONE, result.oneseoEditStatus());
+                }
+            }
+
+            @Nested
+            @DisplayName("원서가 존재하지 않는 경우")
+            class Context_without_oneseo {
+
+                @BeforeEach
+                void setUp() {
+                    given(oneseoRepository.findMemberAndOneseoByMemberId(1L))
+                            .willReturn(new FoundMemberAndOneseoDto(null, null));
+                }
+
+                @Test
+                @DisplayName("수정 가능 여부가 true이고 oneseoEditStatus는 null을 반환한다")
+                void it_returns_true_editability_with_null_status() {
+                    OneseoEditabilityResDto result = queryOneseoEditabilityService.execute(1L);
+                    assertEquals(true, result.oneseoEditability());
+                    assertNull(result.oneseoEditStatus());
+                }
             }
         }
 
@@ -56,12 +98,16 @@ class QueryOneseoEditabilityServiceTest {
             @BeforeEach
             void setUp() {
                 given(entranceTestResultRepository.existsByFirstTestPassYnIsNotNull()).willReturn(true);
+                Oneseo oneseo = mock(Oneseo.class);
+                given(oneseo.getOneseoEditStatus()).willReturn(OneseoEditStatus.NONE);
+                given(oneseoRepository.findMemberAndOneseoByMemberId(1L))
+                        .willReturn(new FoundMemberAndOneseoDto(null, oneseo));
             }
 
             @Test
             @DisplayName("수정 가능 여부가 false인 OneseoEditabilityResDto를 반환한다")
             void it_returns_false_editability() {
-                OneseoEditabilityResDto result = queryOneseoEditabilityService.execute();
+                OneseoEditabilityResDto result = queryOneseoEditabilityService.execute(1L);
                 assertEquals(false, result.oneseoEditability());
             }
         }

--- a/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/RequestOneseoEditPermissionServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/RequestOneseoEditPermissionServiceTest.java
@@ -1,0 +1,142 @@
+package team.themoment.hellogsmv3.domain.oneseo.service;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
+import java.time.LocalTime;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.MockitoAnnotations;
+import org.springframework.http.HttpStatus;
+
+import team.themoment.hellogsmv3.domain.oneseo.entity.EntranceTestResult;
+import team.themoment.hellogsmv3.domain.oneseo.entity.Oneseo;
+import team.themoment.hellogsmv3.domain.oneseo.entity.type.OneseoEditStatus;
+import team.themoment.hellogsmv3.domain.oneseo.entity.type.YesNo;
+import team.themoment.sdk.exception.ExpectedException;
+
+@DisplayName("RequestOneseoEditPermissionService 클래스의")
+class RequestOneseoEditPermissionServiceTest {
+
+    @Mock
+    private OneseoService oneseoService;
+
+    private RequestOneseoEditPermissionService service;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        service = spy(new RequestOneseoEditPermissionService(oneseoService));
+    }
+
+    @Nested
+    @DisplayName("execute 메서드는")
+    class Describe_execute {
+
+        private final Long memberId = 1L;
+
+        @Nested
+        @DisplayName("현재 시간이 09:00 ~ 16:00 범위 밖인 경우")
+        class Context_when_outside_allowed_time {
+
+            @Test
+            @DisplayName("FORBIDDEN ExpectedException을 던진다")
+            void it_throws_forbidden() {
+                given(service.getCurrentTime()).willReturn(LocalTime.of(8, 59));
+
+                ExpectedException ex = assertThrows(ExpectedException.class, () -> service.execute(memberId));
+                assert ex.getStatusCode() == HttpStatus.FORBIDDEN;
+            }
+        }
+
+        @Nested
+        @DisplayName("현재 시간이 09:00 ~ 16:00 범위 내인 경우")
+        class Context_when_within_allowed_time {
+
+            private Oneseo oneseo;
+            private EntranceTestResult entranceTestResult;
+
+            @BeforeEach
+            void setUp() {
+                entranceTestResult = mock(EntranceTestResult.class);
+                oneseo = mock(Oneseo.class);
+                given(oneseo.getEntranceTestResult()).willReturn(entranceTestResult);
+                given(oneseoService.findWithMemberByMemberIdOrThrow(memberId)).willReturn(oneseo);
+                given(service.getCurrentTime()).willReturn(LocalTime.of(10, 0));
+            }
+
+            @Nested
+            @DisplayName("1차 전형이 이미 완료된 경우")
+            class Context_when_first_test_finished {
+
+                @Test
+                @DisplayName("ExpectedException을 던진다")
+                void it_throws_expected_exception() {
+                    given(entranceTestResult.getFirstTestPassYn()).willReturn(YesNo.YES);
+
+                    try (MockedStatic<OneseoService> mockedOneseoService = mockStatic(OneseoService.class)) {
+                        mockedOneseoService.when(() -> OneseoService.isBeforeFirstTest(YesNo.YES))
+                                .thenThrow(new ExpectedException(HttpStatus.FORBIDDEN));
+
+                        assertThrows(ExpectedException.class, () -> service.execute(memberId));
+                    }
+                }
+            }
+
+            @Nested
+            @DisplayName("이미 APPROVED 상태인 경우")
+            class Context_when_already_approved {
+
+                @Test
+                @DisplayName("CONFLICT ExpectedException을 던진다")
+                void it_throws_conflict() {
+                    given(entranceTestResult.getFirstTestPassYn()).willReturn(null);
+                    given(oneseo.getOneseoEditStatus()).willReturn(OneseoEditStatus.APPROVED);
+
+                    ExpectedException ex = assertThrows(ExpectedException.class, () -> service.execute(memberId));
+                    assert ex.getStatusCode() == HttpStatus.CONFLICT;
+                }
+            }
+
+            @Nested
+            @DisplayName("이미 REQUESTED 상태인 경우")
+            class Context_when_already_requested {
+
+                @Test
+                @DisplayName("CONFLICT ExpectedException을 던진다")
+                void it_throws_conflict() {
+                    given(entranceTestResult.getFirstTestPassYn()).willReturn(null);
+                    given(oneseo.getOneseoEditStatus()).willReturn(OneseoEditStatus.REQUESTED);
+
+                    ExpectedException ex = assertThrows(ExpectedException.class, () -> service.execute(memberId));
+                    assert ex.getStatusCode() == HttpStatus.CONFLICT;
+                }
+            }
+
+            @Nested
+            @DisplayName("NONE 상태이고 정상 조건인 경우")
+            class Context_when_none_status_and_valid {
+
+                @Test
+                @DisplayName("requestEditPermit을 호출한다")
+                void it_calls_request_edit_permit() {
+                    given(entranceTestResult.getFirstTestPassYn()).willReturn(null);
+                    given(oneseo.getOneseoEditStatus()).willReturn(OneseoEditStatus.NONE);
+
+                    assertDoesNotThrow(() -> service.execute(memberId));
+                    verify(oneseo).requestEditPermit();
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 개요

원서 접수 기간 중 지원자가 제출한 원서를 수정하고 싶을 때, 어드민에게 수정 권한을 요청하는 흐름을 구현합니다.

## 본문
### 신규 생성
- `OneseoEditStatus` (enum): 원서 수정 권한 상태 (`NONE` → `REQUESTED` → `APPROVED` → `NONE`)
- `RequestOneseoEditPermissionService`: 지원자가 수정 권한을 요청합니다.
- `ApproveOneseoEditPermissionService`: 어드민이 수정 권한 요청을 승인합니다.
- `ModifyOneseoByApplicantService`: 수정 권한이 승인된 지원자가 원서를 수정하고 재제출합니다. 재제출 시 권한이 자동으로 소멸합니다.

### 수정
- `Oneseo`: `oneseoEditStatus` 필드 추가 및 뮤테이터 메서드 3개 추가 (`requestEditPermit`, `approveEditPermit`, `revokeEditPermit`)
- `ModifyOneseoService`: `buildOneseo()`에서 `oneseoEditStatus` 복사 — 어드민 수정 시 상태가 `NONE`으로 초기화되는 버그 방지
- `SearchOneseoResDto`: `oneseoEditStatus` 필드 추가 — 어드민 원서 목록에서 수정 권한 상태에 따라 버튼 활성/비활성 처리 가능
- `CustomOneseoRepositoryImpl`: 원서 검색 쿼리에 `oneseoEditStatus` 반환 추가
- `OneseoEditabilityResDto`: `oneseoEditStatus` 필드 추가
- `QueryOneseoEditabilityService`: 어드민/지원자 모두 `execute(Long memberId)`로 통합, 원서 미존재 시 `oneseoEditStatus = null` 반환
- `OneseoController`: 신규 엔드포인트 3개 추가, `GET /editability` 권한 변경
- `SecurityConfig`: 신규 엔드포인트 권한 추가, `GET /editability` 권한 ADMIN_ONLY → ALL_AUTHENTICATED

### 삭제
- `QueryOneseoEditPermissionRequestsService`: `/oneseo/search` 응답에 `oneseoEditStatus`를 포함하는 방식으로 대체
- `EditPermissionRequestResDto`: 동일한 이유로 삭제
- `CustomOneseoRepository.findAllByEditStatusRequested()`: 동일한 이유로 삭제

### 비즈니스 규칙
- 수정 권한 요청은 **매일 09:00~16:00** 사이에만 가능
- 이미 `REQUESTED` 또는 `APPROVED` 상태에서 재요청 시 `409 CONFLICT`
- 1차 전형 발표 이후 요청 시 거절
- 어드민이 `REQUESTED` 아닌 원서를 승인 시 `400 BAD_REQUEST`
- 원서 수정 권한(`APPROVED`)이 없는 지원자가 `PUT /oneseo/me` 호출 시 `403 FORBIDDEN`
- 재제출 완료 시 수정 권한 자동 소멸 (`APPROVED` → `NONE`)
- 
## API

| Method | Path | 권한 | 설명 |
|--------|------|------|------|
| `POST` | `/oneseo/v3/oneseo/me/request` | APPLICANT, ROOT | 수정 권한 요청 (매일 09:00~16:00) |
| `PATCH` | `/oneseo/v3/oneseo/{memberId}/approval` | ADMIN, ROOT | 수정 권한 승인 |
| `PUT` | `/oneseo/v3/oneseo/me` | APPLICANT, ROOT | 원서 수정 후 재제출 (1차 전형 발표 전까지) |
| `GET` | `/oneseo/v3/oneseo/search` | ADMIN, ROOT | 기존 원서 검색 — `oneseoEditStatus` 필드 추가 |
| `GET` | `/oneseo/v3/editability` | 전체 인증 사용자 | 기존 수정 가능 여부 — `oneseoEditStatus` 필드 추가 |

## 추가
### DB 마이그레이션

`tb_oneseo` 테이블에 컬럼 추가가 필요합니다.

```sql
ALTER TABLE tb_oneseo
    ADD COLUMN oneseo_edit_status VARCHAR(10) NOT NULL DEFAULT 'NONE';
```

---

# RCA 룰

r: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)  
c: 웬만하면 반영해 주세요. (Comment)  
a: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)
