### PR TITLE
[global] Redis 캐시 직렬화 시 BigDecimal 타입 허용 추가

### DIFF
--- a/src/main/java/team/themoment/hellogsmv3/global/config/RedisCacheConfig.java
+++ b/src/main/java/team/themoment/hellogsmv3/global/config/RedisCacheConfig.java
@@ -35,7 +35,7 @@ public class RedisCacheConfig {
                 RedisSerializationContext.SerializationPair.fromSerializer(GenericJacksonJsonRedisSerializer.builder()
                         .enableDefaultTyping(BasicPolymorphicTypeValidator.builder()
                                 .allowIfSubType("team.themoment.hellogsmv3").allowIfSubType(java.util.Collection.class)
-                                .allowIfSubType(java.util.Map.class).build())
+                                .allowIfSubType(java.util.Map.class).allowIfSubType(java.math.BigDecimal.class).build())
                         .build()));
 
         return RedisCacheManager.RedisCacheManagerBuilder.fromConnectionFactory(cf).cacheDefaults(defaultConfig)


### PR DESCRIPTION
## 개요

`oneseo` 캐시의 Redis 직렬화 설정에서 `PolymorphicTypeValidator`가 `BigDecimal` 타입을 허용하지 않아 `/me` 요청 시 500 에러가 발생하는 버그를 수정합니다.

## 본문

`RedisCacheConfig`의 `oneseoConfig`는 `enableDefaultTyping()`으로 JSON에 타입 정보(`@class`)를 포함시킵니다. 역직렬화 시 `BasicPolymorphicTypeValidator`가 해당 타입의 허용 여부를 검사하는데, 기존 허용 목록에 `java.math.BigDecimal`이 누락되어 있었습니다.

`CalculatedScoreResDto`, `GeneralSubjectsScoreDetailResDto`, `MiddleSchoolAchievementResDto` 등 oneseo 응답 DTO에 `BigDecimal` 필드가 포함되어 있어, Redis FLUSH 이후 DB에서 데이터를 조회하고 Redis에 재저장하는 과정에서 직렬화 예외가 발생했습니다.

### 변경

- `RedisCacheConfig` — `BasicPolymorphicTypeValidator`에 `java.math.BigDecimal` 허용 타입 추가