### PR TITLE
[oneseo] 임시저장 응답에 calculatedScore 및 absentDaysCount 누락 수정

### DIFF
--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/OneseoTempStorageService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/OneseoTempStorageService.java
@@ -43,7 +43,10 @@ public class OneseoTempStorageService {
         MiddleSchoolAchievementResDto middleSchoolAchievementResDto = buildMiddleSchoolAchievementResDto(reqDto);
         CalculatedScoreResDto calculatedScoreResDto = calculateScore(reqDto);
 
-        return buildFoundOneseoResDto(reqDto, oneseoPrivacyDetailResDto, middleSchoolAchievementResDto, step,
+        return buildFoundOneseoResDto(reqDto,
+                oneseoPrivacyDetailResDto,
+                middleSchoolAchievementResDto,
+                step,
                 calculatedScoreResDto);
     }
 
@@ -80,16 +83,15 @@ public class OneseoTempStorageService {
                 .artsPhysicalAchievement(middleSchoolAchievement.artsPhysicalAchievement())
                 .artsPhysicalSubjects(middleSchoolAchievement.artsPhysicalSubjects()).absentDays(absentDays)
                 .absentDaysCount(OneseoService.calcAbsentDaysCount(absentDays, attendanceDays))
-                .attendanceDays(attendanceDays)
-                .volunteerTime(middleSchoolAchievement.volunteerTime())
+                .attendanceDays(attendanceDays).volunteerTime(middleSchoolAchievement.volunteerTime())
                 .liberalSystem(middleSchoolAchievement.liberalSystem())
                 .freeSemester(middleSchoolAchievement.freeSemester()).gedAvgScore(middleSchoolAchievement.gedAvgScore())
                 .build();
     }
 
     private CalculatedScoreResDto calculateScore(OneseoTempReqDto reqDto) {
-        LambdaScoreCalculatorReqDto lambdaRequest =
-                LambdaScoreCalculatorReqDto.from(reqDto.middleSchoolAchievement(), reqDto.graduationType());
+        LambdaScoreCalculatorReqDto lambdaRequest = LambdaScoreCalculatorReqDto.from(reqDto.middleSchoolAchievement(),
+                reqDto.graduationType());
         return lambdaScoreCalculatorClient.calculateScore(lambdaRequest);
     }
 

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/OneseoTempStorageService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/OneseoTempStorageService.java
@@ -14,11 +14,14 @@ import team.themoment.hellogsmv3.domain.member.entity.Member;
 import team.themoment.hellogsmv3.domain.member.service.MemberService;
 import team.themoment.hellogsmv3.domain.oneseo.dto.request.MiddleSchoolAchievementReqDto;
 import team.themoment.hellogsmv3.domain.oneseo.dto.request.OneseoTempReqDto;
+import team.themoment.hellogsmv3.domain.oneseo.dto.response.CalculatedScoreResDto;
 import team.themoment.hellogsmv3.domain.oneseo.dto.response.DesiredMajorsResDto;
 import team.themoment.hellogsmv3.domain.oneseo.dto.response.FoundOneseoResDto;
 import team.themoment.hellogsmv3.domain.oneseo.dto.response.MiddleSchoolAchievementResDto;
 import team.themoment.hellogsmv3.domain.oneseo.dto.response.OneseoPrivacyDetailResDto;
 import team.themoment.hellogsmv3.domain.oneseo.repository.OneseoRepository;
+import team.themoment.hellogsmv3.global.thirdParty.feign.client.dto.request.LambdaScoreCalculatorReqDto;
+import team.themoment.hellogsmv3.global.thirdParty.feign.client.lambda.LambdaScoreCalculatorClient;
 import team.themoment.sdk.exception.ExpectedException;
 
 @Service
@@ -27,6 +30,7 @@ public class OneseoTempStorageService {
 
     private final MemberService memberService;
     private final OneseoRepository oneseoRepository;
+    private final LambdaScoreCalculatorClient lambdaScoreCalculatorClient;
 
     @CachePut(value = ONESEO_CACHE_VALUE, key = "#memberId")
     @Transactional(readOnly = true)
@@ -37,8 +41,10 @@ public class OneseoTempStorageService {
 
         OneseoPrivacyDetailResDto oneseoPrivacyDetailResDto = buildOneseoPrivacyDetailResDto(member, reqDto);
         MiddleSchoolAchievementResDto middleSchoolAchievementResDto = buildMiddleSchoolAchievementResDto(reqDto);
+        CalculatedScoreResDto calculatedScoreResDto = calculateScore(reqDto);
 
-        return buildFoundOneseoResDto(reqDto, oneseoPrivacyDetailResDto, middleSchoolAchievementResDto, step);
+        return buildFoundOneseoResDto(reqDto, oneseoPrivacyDetailResDto, middleSchoolAchievementResDto, step,
+                calculatedScoreResDto);
     }
 
     private void isNotExistOneseo(Member member) {
@@ -73,23 +79,31 @@ public class OneseoTempStorageService {
                 .newSubjects(middleSchoolAchievement.newSubjects())
                 .artsPhysicalAchievement(middleSchoolAchievement.artsPhysicalAchievement())
                 .artsPhysicalSubjects(middleSchoolAchievement.artsPhysicalSubjects()).absentDays(absentDays)
-                .absentDaysCount(null).attendanceDays(attendanceDays)
+                .absentDaysCount(OneseoService.calcAbsentDaysCount(absentDays, attendanceDays))
+                .attendanceDays(attendanceDays)
                 .volunteerTime(middleSchoolAchievement.volunteerTime())
                 .liberalSystem(middleSchoolAchievement.liberalSystem())
                 .freeSemester(middleSchoolAchievement.freeSemester()).gedAvgScore(middleSchoolAchievement.gedAvgScore())
                 .build();
     }
 
+    private CalculatedScoreResDto calculateScore(OneseoTempReqDto reqDto) {
+        LambdaScoreCalculatorReqDto lambdaRequest =
+                LambdaScoreCalculatorReqDto.from(reqDto.middleSchoolAchievement(), reqDto.graduationType());
+        return lambdaScoreCalculatorClient.calculateScore(lambdaRequest);
+    }
+
     private FoundOneseoResDto buildFoundOneseoResDto(OneseoTempReqDto reqDto,
             OneseoPrivacyDetailResDto oneseoPrivacyDetailResDto,
             MiddleSchoolAchievementResDto middleSchoolAchievementResDto,
-            Integer step) {
+            Integer step,
+            CalculatedScoreResDto calculatedScoreResDto) {
 
         return FoundOneseoResDto.builder().oneseoId(null).submitCode(null).wantedScreening(reqDto.screening())
                 .desiredMajors(DesiredMajorsResDto.builder().firstDesiredMajor(reqDto.firstDesiredMajor())
                         .secondDesiredMajor(reqDto.secondDesiredMajor()).thirdDesiredMajor(reqDto.thirdDesiredMajor())
                         .build())
                 .privacyDetail(oneseoPrivacyDetailResDto).middleSchoolAchievement(middleSchoolAchievementResDto)
-                .step(step).build();
+                .calculatedScore(calculatedScoreResDto).step(step).build();
     }
 }

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/OneseoTempStorageService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/OneseoTempStorageService.java
@@ -3,6 +3,7 @@ package team.themoment.hellogsmv3.domain.oneseo.service;
 import static team.themoment.hellogsmv3.domain.oneseo.service.OneseoService.*;
 
 import java.util.List;
+import java.util.Objects;
 
 import org.springframework.cache.annotation.CachePut;
 import org.springframework.http.HttpStatus;
@@ -82,17 +83,30 @@ public class OneseoTempStorageService {
                 .newSubjects(middleSchoolAchievement.newSubjects())
                 .artsPhysicalAchievement(middleSchoolAchievement.artsPhysicalAchievement())
                 .artsPhysicalSubjects(middleSchoolAchievement.artsPhysicalSubjects()).absentDays(absentDays)
-                .absentDaysCount(OneseoService.calcAbsentDaysCount(absentDays, attendanceDays))
-                .attendanceDays(attendanceDays).volunteerTime(middleSchoolAchievement.volunteerTime())
+                .absentDaysCount(calcAbsentDaysCountSafely(absentDays, attendanceDays)).attendanceDays(attendanceDays)
+                .volunteerTime(middleSchoolAchievement.volunteerTime())
                 .liberalSystem(middleSchoolAchievement.liberalSystem())
                 .freeSemester(middleSchoolAchievement.freeSemester()).gedAvgScore(middleSchoolAchievement.gedAvgScore())
                 .build();
     }
 
     private CalculatedScoreResDto calculateScore(OneseoTempReqDto reqDto) {
+        if (reqDto.middleSchoolAchievement() == null) {
+            return null;
+        }
         LambdaScoreCalculatorReqDto lambdaRequest = LambdaScoreCalculatorReqDto.from(reqDto.middleSchoolAchievement(),
                 reqDto.graduationType());
         return lambdaScoreCalculatorClient.calculateScore(lambdaRequest);
+    }
+
+    private Integer calcAbsentDaysCountSafely(List<Integer> absentDays, List<Integer> attendanceDays) {
+        if (absentDays == null || attendanceDays == null) {
+            return null;
+        }
+        if (absentDays.stream().anyMatch(Objects::isNull) || attendanceDays.stream().anyMatch(Objects::isNull)) {
+            return null;
+        }
+        return OneseoService.calcAbsentDaysCount(absentDays, attendanceDays);
     }
 
     private FoundOneseoResDto buildFoundOneseoResDto(OneseoTempReqDto reqDto,

--- a/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/OneseoTempStorageServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/OneseoTempStorageServiceTest.java
@@ -1,8 +1,10 @@
 package team.themoment.hellogsmv3.domain.oneseo.service;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 
+import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.List;
 
@@ -20,10 +22,13 @@ import team.themoment.hellogsmv3.domain.member.entity.type.Sex;
 import team.themoment.hellogsmv3.domain.member.service.MemberService;
 import team.themoment.hellogsmv3.domain.oneseo.dto.request.MiddleSchoolAchievementReqDto;
 import team.themoment.hellogsmv3.domain.oneseo.dto.request.OneseoTempReqDto;
+import team.themoment.hellogsmv3.domain.oneseo.dto.response.CalculatedScoreResDto;
 import team.themoment.hellogsmv3.domain.oneseo.dto.response.FoundOneseoResDto;
 import team.themoment.hellogsmv3.domain.oneseo.entity.type.GraduationType;
 import team.themoment.hellogsmv3.domain.oneseo.entity.type.Major;
 import team.themoment.hellogsmv3.domain.oneseo.repository.OneseoRepository;
+import team.themoment.hellogsmv3.global.thirdParty.feign.client.dto.request.LambdaScoreCalculatorReqDto;
+import team.themoment.hellogsmv3.global.thirdParty.feign.client.lambda.LambdaScoreCalculatorClient;
 import team.themoment.sdk.exception.ExpectedException;
 
 @DisplayName("OneseoTempStorageService 클래스의")
@@ -33,6 +38,8 @@ public class OneseoTempStorageServiceTest {
     private MemberService memberService;
     @Mock
     private OneseoRepository oneseoRepository;
+    @Mock
+    private LambdaScoreCalculatorClient lambdaScoreCalculatorClient;
     @InjectMocks
     private OneseoTempStorageService oneseoTempStorageService;
 
@@ -81,9 +88,16 @@ public class OneseoTempStorageServiceTest {
             @Nested
             @DisplayName("회원이 원서를 제출하지 않았다면")
             class Oneseo_not_exist {
+                private final CalculatedScoreResDto calculatedScoreResDto = CalculatedScoreResDto.builder()
+                        .generalSubjectsScore(new BigDecimal("80.000"))
+                        .artsPhysicalSubjectsScore(new BigDecimal("10.000")).attendanceScore(new BigDecimal("5.000"))
+                        .volunteerScore(new BigDecimal("5.000")).totalScore(new BigDecimal("100.000")).build();
+
                 @BeforeEach
                 void setUp() {
                     given(oneseoRepository.existsByMember(member)).willReturn(false);
+                    given(lambdaScoreCalculatorClient.calculateScore(any(LambdaScoreCalculatorReqDto.class)))
+                            .willReturn(calculatedScoreResDto);
                 }
 
                 @Test
@@ -143,6 +157,7 @@ public class OneseoTempStorageServiceTest {
                             resDto.middleSchoolAchievement().freeSemester());
                     assertEquals(reqDto.middleSchoolAchievement().gedAvgScore(),
                             resDto.middleSchoolAchievement().gedAvgScore());
+                    assertEquals(calculatedScoreResDto, resDto.calculatedScore());
                     assertEquals(step, resDto.step());
                 }
             }


### PR DESCRIPTION
## 개요

원서 임시저장(`POST /oneseo/v3/temp-storage`) 후 원서 조회 시 응답에 `calculatedScore`와 `absentDaysCount`가 누락되는 버그를 수정합니다.

## 본문

임시저장 시 `OneseoTempStorageService`가 `@CachePut`으로 캐시를 덮어쓰기 때문에, 이후 `GET /oneseo/v3/oneseo/me` 요청은 DB 대신 캐시에서 임시저장 데이터를 반환합니다.
그런데 임시저장 서비스가 응답을 구성할 때 두 가지 값이 빠져 있었습니다.

- `calculatedScore`: `buildFoundOneseoResDto()`에서 `.calculatedScore()` 세팅 자체가 생략되어 `null`이 되었고, `@JsonInclude(NON_NULL)` 설정에 의해 JSON 응답에서 완전히 제외됨
- `absentDaysCount`: `buildMiddleSchoolAchievementResDto()`에서 `.absentDaysCount(null)`로 하드코딩되어 있어 항상 `null` 반환

### 변경

- `OneseoTempStorageService`에 `LambdaScoreCalculatorClient` 의존성 추가
- `calculateScore()` private 메서드 추가 — `LambdaScoreCalculatorReqDto.from()`으로 변환 후 Lambda 호출
- `execute()`에서 점수 계산 결과를 `buildFoundOneseoResDto()`에 전달
- `absentDaysCount(null)` → `OneseoService.calcAbsentDaysCount(absentDays, attendanceDays)` 호출로 교체