### PR TITLE
[oneseo] 자유학기 성적 복사값이 원서 응답에 노출되는 버그 수정

### DIFF
--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/QueryOneseoByIdService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/QueryOneseoByIdService.java
@@ -22,6 +22,13 @@ import team.themoment.hellogsmv3.domain.oneseo.repository.OneseoPrivacyDetailRep
 @RequiredArgsConstructor
 public class QueryOneseoByIdService {
 
+    private static final String LIBERAL_YEAR_SYSTEM = "자유학년제";
+    private static final String FREE_SEMESTER_1_2 = "1-2";
+    private static final String FREE_SEMESTER_2_1 = "2-1";
+    private static final String FREE_SEMESTER_2_2 = "2-2";
+    private static final String FREE_SEMESTER_3_1 = "3-1";
+    private static final String FREE_SEMESTER_3_2 = "3-2";
+
     private final OneseoPrivacyDetailRepository oneseoPrivacyDetailRepository;
     private final MiddleSchoolAchievementRepository middleSchoolAchievementRepository;
     private final MemberService memberService;
@@ -108,15 +115,17 @@ public class QueryOneseoByIdService {
         List<Integer> achievement3_2 = middleSchoolAchievement.getAchievement3_2();
 
         // 점수 계산을 위해 복사된 자유학기 성적을 응답에서 null로 복원
-        if ("자유학년제".equals(liberalSystem)) {
+        if (LIBERAL_YEAR_SYSTEM.equals(liberalSystem)) {
             achievement1_2 = null;
-        } else if (freeSemester != null) {
+        }
+
+        if (freeSemester != null) {
             switch (freeSemester) {
-                case "1-2" -> achievement1_2 = null;
-                case "2-1" -> achievement2_1 = null;
-                case "2-2" -> achievement2_2 = null;
-                case "3-1" -> achievement3_1 = null;
-                case "3-2" -> achievement3_2 = null;
+                case FREE_SEMESTER_1_2 -> achievement1_2 = null;
+                case FREE_SEMESTER_2_1 -> achievement2_1 = null;
+                case FREE_SEMESTER_2_2 -> achievement2_2 = null;
+                case FREE_SEMESTER_3_1 -> achievement3_1 = null;
+                case FREE_SEMESTER_3_2 -> achievement3_2 = null;
             }
         }
 

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/QueryOneseoByIdService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/QueryOneseoByIdService.java
@@ -98,20 +98,37 @@ public class QueryOneseoByIdService {
         List<Integer> attendanceDays = middleSchoolAchievement.getAttendanceDays();
         Integer absentDaysCount = OneseoService.calcAbsentDaysCount(absentDays, attendanceDays);
 
-        return MiddleSchoolAchievementResDto.builder().achievement1_2(middleSchoolAchievement.getAchievement1_2())
-                .achievement2_1(middleSchoolAchievement.getAchievement2_1())
-                .achievement2_2(middleSchoolAchievement.getAchievement2_2())
-                .achievement3_1(middleSchoolAchievement.getAchievement3_1())
-                .achievement3_2(middleSchoolAchievement.getAchievement3_2())
+        String liberalSystem = middleSchoolAchievement.getLiberalSystem();
+        String freeSemester = middleSchoolAchievement.getFreeSemester();
+
+        List<Integer> achievement1_2 = middleSchoolAchievement.getAchievement1_2();
+        List<Integer> achievement2_1 = middleSchoolAchievement.getAchievement2_1();
+        List<Integer> achievement2_2 = middleSchoolAchievement.getAchievement2_2();
+        List<Integer> achievement3_1 = middleSchoolAchievement.getAchievement3_1();
+        List<Integer> achievement3_2 = middleSchoolAchievement.getAchievement3_2();
+
+        // 점수 계산을 위해 복사된 자유학기 성적을 응답에서 null로 복원
+        if ("자유학년제".equals(liberalSystem)) {
+            achievement1_2 = null;
+        } else if (freeSemester != null) {
+            switch (freeSemester) {
+                case "1-2" -> achievement1_2 = null;
+                case "2-1" -> achievement2_1 = null;
+                case "2-2" -> achievement2_2 = null;
+                case "3-1" -> achievement3_1 = null;
+                case "3-2" -> achievement3_2 = null;
+            }
+        }
+
+        return MiddleSchoolAchievementResDto.builder().achievement1_2(achievement1_2).achievement2_1(achievement2_1)
+                .achievement2_2(achievement2_2).achievement3_1(achievement3_1).achievement3_2(achievement3_2)
                 .generalSubjects(middleSchoolAchievement.getGeneralSubjects())
                 .newSubjects(middleSchoolAchievement.getNewSubjects())
                 .artsPhysicalAchievement(middleSchoolAchievement.getArtsPhysicalAchievement())
                 .artsPhysicalSubjects(middleSchoolAchievement.getArtsPhysicalSubjects()).absentDays(absentDays)
                 .absentDaysCount(absentDaysCount).attendanceDays(attendanceDays)
-                .volunteerTime(middleSchoolAchievement.getVolunteerTime())
-                .liberalSystem(middleSchoolAchievement.getLiberalSystem())
-                .freeSemester(middleSchoolAchievement.getFreeSemester())
-                .gedAvgScore(middleSchoolAchievement.getGedAvgScore()).build();
+                .volunteerTime(middleSchoolAchievement.getVolunteerTime()).liberalSystem(liberalSystem)
+                .freeSemester(freeSemester).gedAvgScore(middleSchoolAchievement.getGedAvgScore()).build();
     }
 
     private FoundOneseoResDto buildFoundOneseoResDto(Oneseo oneseo,

--- a/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/QueryOneseoByIdServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/QueryOneseoByIdServiceTest.java
@@ -1,6 +1,7 @@
 package team.themoment.hellogsmv3.domain.oneseo.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.when;
@@ -229,7 +230,98 @@ class QueryOneseoByIdServiceTest {
                 .achievement2_2(integerList).achievement3_1(integerList).achievement3_2(integerList)
                 .generalSubjects(stringList).newSubjects(stringList)
                 .artsPhysicalAchievement(List.of(3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3)).artsPhysicalSubjects(stringList)
-                .absentDays(integerList).attendanceDays(integerList).volunteerTime(integerList).liberalSystem("자유학년제")
+                .absentDays(integerList).attendanceDays(integerList).volunteerTime(integerList).liberalSystem("자유학기제")
                 .freeSemester(null).gedAvgScore(bigDecimal).build();
+    }
+
+    private MiddleSchoolAchievement buildMiddleSchoolAchievementWithFreeSemester(String liberalSystem,
+            String freeSemester) {
+        List<Integer> integerList = List.of(1, 2, 3, 4, 5);
+        List<String> stringList = List.of("과목1", "과목2", "과목3");
+
+        return MiddleSchoolAchievement.builder().achievement1_2(integerList).achievement2_1(integerList)
+                .achievement2_2(integerList).achievement3_1(integerList).achievement3_2(integerList)
+                .generalSubjects(stringList).newSubjects(stringList)
+                .artsPhysicalAchievement(List.of(3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3)).artsPhysicalSubjects(stringList)
+                .absentDays(integerList).attendanceDays(integerList).volunteerTime(integerList)
+                .liberalSystem(liberalSystem).freeSemester(freeSemester).gedAvgScore(null).build();
+    }
+
+    @Nested
+    @DisplayName("자유학기 성적 null 복원 기능은")
+    class Describe_freeSemesterNullRestore {
+
+        private final Long memberId = 1L;
+
+        private void setUpWithFreeSemester(String liberalSystem, String freeSemester) {
+            Member member = buildMember(memberId);
+            MiddleSchoolAchievement msa = buildMiddleSchoolAchievementWithFreeSemester(liberalSystem, freeSemester);
+            OneseoPrivacyDetail privacyDetail = buildOneseoPrivacyDetail();
+            Oneseo oneseo = buildOneseo(member, msa, privacyDetail);
+
+            given(oneseoService.findWithMemberByMemberIdOrThrow(memberId)).willReturn(oneseo);
+            given(oneseoPrivacyDetailRepository.findByOneseo(oneseo)).willReturn(privacyDetail);
+            given(middleSchoolAchievementRepository.findByOneseo(oneseo)).willReturn(msa);
+        }
+
+        @Test
+        @DisplayName("자유학년제인 경우 응답의 achievement1_2가 null이다")
+        void it_nulls_achievement1_2_for_liberal_year() {
+            setUpWithFreeSemester("자유학년제", null);
+            MiddleSchoolAchievementResDto result = queryOneseoByIdService.execute(memberId).middleSchoolAchievement();
+            assertNull(result.achievement1_2());
+        }
+
+        @Test
+        @DisplayName("freeSemester가 1-2인 경우 응답의 achievement1_2가 null이다")
+        void it_nulls_achievement1_2_for_free_semester_1_2() {
+            setUpWithFreeSemester("자유학기제", "1-2");
+            MiddleSchoolAchievementResDto result = queryOneseoByIdService.execute(memberId).middleSchoolAchievement();
+            assertNull(result.achievement1_2());
+        }
+
+        @Test
+        @DisplayName("freeSemester가 2-1인 경우 응답의 achievement2_1이 null이다")
+        void it_nulls_achievement2_1_for_free_semester_2_1() {
+            setUpWithFreeSemester("자유학기제", "2-1");
+            MiddleSchoolAchievementResDto result = queryOneseoByIdService.execute(memberId).middleSchoolAchievement();
+            assertNull(result.achievement2_1());
+        }
+
+        @Test
+        @DisplayName("freeSemester가 2-2인 경우 응답의 achievement2_2가 null이다")
+        void it_nulls_achievement2_2_for_free_semester_2_2() {
+            setUpWithFreeSemester("자유학기제", "2-2");
+            MiddleSchoolAchievementResDto result = queryOneseoByIdService.execute(memberId).middleSchoolAchievement();
+            assertNull(result.achievement2_2());
+        }
+
+        @Test
+        @DisplayName("freeSemester가 3-1인 경우 응답의 achievement3_1이 null이다")
+        void it_nulls_achievement3_1_for_free_semester_3_1() {
+            setUpWithFreeSemester("자유학기제", "3-1");
+            MiddleSchoolAchievementResDto result = queryOneseoByIdService.execute(memberId).middleSchoolAchievement();
+            assertNull(result.achievement3_1());
+        }
+
+        @Test
+        @DisplayName("freeSemester가 3-2인 경우 응답의 achievement3_2가 null이다")
+        void it_nulls_achievement3_2_for_free_semester_3_2() {
+            setUpWithFreeSemester("자유학기제", "3-2");
+            MiddleSchoolAchievementResDto result = queryOneseoByIdService.execute(memberId).middleSchoolAchievement();
+            assertNull(result.achievement3_2());
+        }
+
+        @Test
+        @DisplayName("freeSemester가 2-2인 경우 나머지 성적은 그대로 반환된다")
+        void it_keeps_other_achievements_for_free_semester_2_2() {
+            setUpWithFreeSemester("자유학기제", "2-2");
+            MiddleSchoolAchievementResDto result = queryOneseoByIdService.execute(memberId).middleSchoolAchievement();
+            assertEquals(List.of(1, 2, 3, 4, 5), result.achievement1_2());
+            assertEquals(List.of(1, 2, 3, 4, 5), result.achievement2_1());
+            assertNull(result.achievement2_2());
+            assertEquals(List.of(1, 2, 3, 4, 5), result.achievement3_1());
+            assertEquals(List.of(1, 2, 3, 4, 5), result.achievement3_2());
+        }
     }
 }


### PR DESCRIPTION
  ## 개요                                                                                                                                                       
                                                                                                                                                                 
   자유학기 성적이 원서 조회 응답에 복사값으로 노출되어, 원서 출력 시 자유학기 칸에 인접 학기 내용이 표시되는 버그를 수정합니다. (Issue #342)                    
                                                                                                                                                               
   ## 본문                                                                                                                                                     
                                         
   `buildCalcDtoWithFillEmpty()`는 점수 계산을 위해 자유학기 슬롯에 인접 학기 성적을 복사하여 `MiddleSchoolAchievement` 엔티티에 저장합니다.
   그런데 `QueryOneseoByIdService.buildMiddleSchoolAchievementResDto()`가 `freeSemester` 확인 없이 이 복사값을 그대로 응답에 포함시켜, 원서 출력 시 자유학기
   칸에 1학기 내용이 표시되는 문제가 발생했습니다.

   - `freeSemester = "2-2"` → DB의 `achievement2_2`에는 `achievement2_1` 복사값이 저장됨 → 원서에 2학기 칸에 1학기 내용 출력

   ### 변경

   - `QueryOneseoByIdService.buildMiddleSchoolAchievementResDto()`에서 응답 빌드 시 `liberalSystem` / `freeSemester` 값에 따라 해당 학기 성적을 `null`로
   복원하여 반환
   - DB의 복사값은 유지 — 점수 계산 로직(`buildCalcDtoWithFillEmpty`)에는 영향 없음
   - 자유학년제(`liberalSystem = "자유학년제"`)도 동일하게 `achievement1_2`를 `null`로 복원

   복원하여 반환
   - DB의 복사값은 유지 — 점수 계산 로직(`buildCalcDtoWithFillEmpty`)에는 영향 없음
   - 자유학년제(`liberalSystem = "자유학년제"`)도 동일하게 `achievement1_2`를 `null`로 복원

   ---                                                             
                                       
   # RCA 룰                                                             
      
   r: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)
   c: 웬만하면 반영해 주세요. (Comment)       
   a: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)
