### PR TITLE
[oneseo] 예체능 점수 미입력 시 임시저장 Lambda 호출 차단

### DIFF
--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyOneseoService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyOneseoService.java
@@ -275,7 +275,8 @@ public class ModifyOneseoService {
                 .achievement3_2(validationGeneralAchievement(calcDto.achievement3_2()))
                 .generalSubjects(updatedMiddleSchoolAchievement.generalSubjects())
                 .newSubjects(updatedMiddleSchoolAchievement.newSubjects())
-                .artsPhysicalAchievement(validationArtsPhysicalAchievement(calcDto.artsPhysicalAchievement()))
+                .artsPhysicalAchievement(validationArtsPhysicalAchievement(calcDto.artsPhysicalAchievement(),
+                        updatedMiddleSchoolAchievement.artsPhysicalSubjects()))
                 .artsPhysicalSubjects(updatedMiddleSchoolAchievement.artsPhysicalSubjects())
                 .absentDays(calcDto.absentDays()).attendanceDays(calcDto.attendanceDays())
                 .volunteerTime(calcDto.volunteerTime()).liberalSystem(calcDto.liberalSystem())
@@ -309,9 +310,12 @@ public class ModifyOneseoService {
         return achievements;
     }
 
-    private List<Integer> validationArtsPhysicalAchievement(List<Integer> achievements) {
+    private List<Integer> validationArtsPhysicalAchievement(List<Integer> achievements, List<String> subjects) {
         if (achievements == null)
             return null;
+
+        if (subjects != null && !subjects.isEmpty() && achievements.isEmpty())
+            throw new ExpectedException("예체능 성취점수가 비어있습니다.", HttpStatus.BAD_REQUEST);
 
         achievements.forEach(achievement -> {
             if (achievement != 0 && (achievement > 5 || achievement < 3))

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyOneseoService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyOneseoService.java
@@ -6,7 +6,6 @@ import static team.themoment.hellogsmv3.domain.oneseo.service.OneseoService.isVa
 import java.util.List;
 
 import org.springframework.cache.annotation.CachePut;
-import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -24,7 +23,6 @@ import team.themoment.hellogsmv3.domain.oneseo.entity.type.Screening;
 import team.themoment.hellogsmv3.domain.oneseo.repository.*;
 import team.themoment.hellogsmv3.global.thirdParty.feign.client.dto.request.LambdaScoreCalculatorReqDto;
 import team.themoment.hellogsmv3.global.thirdParty.feign.client.lambda.LambdaScoreCalculatorClient;
-import team.themoment.sdk.exception.ExpectedException;
 
 @Service
 @RequiredArgsConstructor
@@ -267,16 +265,12 @@ public class ModifyOneseoService {
                 reqDto.graduationType());
 
         MiddleSchoolAchievement modifiedMiddleSchoolAchievement = MiddleSchoolAchievement.builder()
-                .id(middleSchoolAchievement.getId()).oneseo(oneseo)
-                .achievement1_2(validationGeneralAchievement(calcDto.achievement1_2()))
-                .achievement2_1(validationGeneralAchievement(calcDto.achievement2_1()))
-                .achievement2_2(validationGeneralAchievement(calcDto.achievement2_2()))
-                .achievement3_1(validationGeneralAchievement(calcDto.achievement3_1()))
-                .achievement3_2(validationGeneralAchievement(calcDto.achievement3_2()))
+                .id(middleSchoolAchievement.getId()).oneseo(oneseo).achievement1_2(calcDto.achievement1_2())
+                .achievement2_1(calcDto.achievement2_1()).achievement2_2(calcDto.achievement2_2())
+                .achievement3_1(calcDto.achievement3_1()).achievement3_2(calcDto.achievement3_2())
                 .generalSubjects(updatedMiddleSchoolAchievement.generalSubjects())
                 .newSubjects(updatedMiddleSchoolAchievement.newSubjects())
-                .artsPhysicalAchievement(validationArtsPhysicalAchievement(calcDto.artsPhysicalAchievement(),
-                        updatedMiddleSchoolAchievement.artsPhysicalSubjects()))
+                .artsPhysicalAchievement(calcDto.artsPhysicalAchievement())
                 .artsPhysicalSubjects(updatedMiddleSchoolAchievement.artsPhysicalSubjects())
                 .absentDays(calcDto.absentDays()).attendanceDays(calcDto.attendanceDays())
                 .volunteerTime(calcDto.volunteerTime()).liberalSystem(calcDto.liberalSystem())
@@ -298,30 +292,4 @@ public class ModifyOneseoService {
         }
     }
 
-    private List<Integer> validationGeneralAchievement(List<Integer> achievements) {
-        if (achievements == null)
-            return null;
-
-        achievements.forEach(achievement -> {
-            if (achievement > 5 || achievement < 0)
-                throw new ExpectedException("올바르지 않은 일반교과 등급이 입력되었습니다.", HttpStatus.BAD_REQUEST);
-        });
-
-        return achievements;
-    }
-
-    private List<Integer> validationArtsPhysicalAchievement(List<Integer> achievements, List<String> subjects) {
-        if (achievements == null)
-            return null;
-
-        if (subjects != null && !subjects.isEmpty() && achievements.isEmpty())
-            throw new ExpectedException("예체능 성취점수가 비어있습니다.", HttpStatus.BAD_REQUEST);
-
-        achievements.forEach(achievement -> {
-            if (achievement != 0 && (achievement > 5 || achievement < 3))
-                throw new ExpectedException("올바르지 않은 예체능 등급이 입력되었습니다.", HttpStatus.BAD_REQUEST);
-        });
-
-        return achievements;
-    }
 }

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/OneseoService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/OneseoService.java
@@ -100,11 +100,11 @@ public class OneseoService {
     }
 
     private static List<Integer> validationArtsPhysicalAchievement(List<Integer> achievements, List<String> subjects) {
+        if (subjects != null && !subjects.isEmpty() && (achievements == null || achievements.isEmpty()))
+            throw new ExpectedException("예체능 성취점수가 비어있습니다.", HttpStatus.BAD_REQUEST);
+
         if (achievements == null)
             return null;
-
-        if (subjects != null && !subjects.isEmpty() && achievements.isEmpty())
-            throw new ExpectedException("예체능 성취점수가 비어있습니다.", HttpStatus.BAD_REQUEST);
 
         achievements.forEach(achievement -> {
             if (achievement != 0 && (achievement > 5 || achievement < 3))

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/OneseoService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/OneseoService.java
@@ -92,15 +92,19 @@ public class OneseoService {
                 .achievement2_2(validationGeneralAchievement(tmpAchievement2_2))
                 .achievement3_1(validationGeneralAchievement(tmpAchievement3_1))
                 .achievement3_2(validationGeneralAchievement(tmpAchievement3_2))
-                .artsPhysicalAchievement(validationArtsPhysicalAchievement(dto.artsPhysicalAchievement()))
+                .artsPhysicalAchievement(
+                        validationArtsPhysicalAchievement(dto.artsPhysicalAchievement(), dto.artsPhysicalSubjects()))
                 .absentDays(dto.absentDays()).attendanceDays(dto.attendanceDays()).volunteerTime(dto.volunteerTime())
                 .liberalSystem(dto.liberalSystem()).freeSemester(dto.freeSemester()).gedAvgScore(dto.gedAvgScore());
         return builder.build();
     }
 
-    private static List<Integer> validationArtsPhysicalAchievement(List<Integer> achievements) {
+    private static List<Integer> validationArtsPhysicalAchievement(List<Integer> achievements, List<String> subjects) {
         if (achievements == null)
             return null;
+
+        if (subjects != null && !subjects.isEmpty() && achievements.isEmpty())
+            throw new ExpectedException("예체능 성취점수가 비어있습니다.", HttpStatus.BAD_REQUEST);
 
         achievements.forEach(achievement -> {
             if (achievement != 0 && (achievement > 5 || achievement < 3))

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/OneseoTempStorageService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/OneseoTempStorageService.java
@@ -91,10 +91,18 @@ public class OneseoTempStorageService {
     }
 
     private CalculatedScoreResDto calculateScore(OneseoTempReqDto reqDto) {
-        if (reqDto.middleSchoolAchievement() == null) {
+        MiddleSchoolAchievementReqDto achievement = reqDto.middleSchoolAchievement();
+        if (achievement == null) {
             return null;
         }
-        LambdaScoreCalculatorReqDto lambdaRequest = LambdaScoreCalculatorReqDto.from(reqDto.middleSchoolAchievement(),
+
+        List<String> subjects = achievement.artsPhysicalSubjects();
+        List<Integer> achievements = achievement.artsPhysicalAchievement();
+        if (subjects != null && !subjects.isEmpty() && (achievements == null || achievements.isEmpty())) {
+            return null;
+        }
+
+        LambdaScoreCalculatorReqDto lambdaRequest = LambdaScoreCalculatorReqDto.from(achievement,
                 reqDto.graduationType());
         return lambdaScoreCalculatorClient.calculateScore(lambdaRequest);
     }

--- a/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/OneseoServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/OneseoServiceTest.java
@@ -482,6 +482,30 @@ public class OneseoServiceTest {
             }
         }
 
+        @Nested
+        @DisplayName("예체능 과목이 있는데 예체능 성취점수가 빈 배열이면")
+        class Context_with_arts_physical_subjects_but_empty_achievement {
+            private GraduationType graduationType;
+
+            @BeforeEach
+            void setUp() {
+                middleSchoolAchievementReqDto = createDefaultDtoBuilder()
+                        .artsPhysicalSubjects(List.of("체육", "음악", "미술")).artsPhysicalAchievement(new ArrayList<>())
+                        .build();
+                graduationType = CANDIDATE;
+            }
+
+            @Test
+            @DisplayName("ExpectedException을 던진다.")
+            void it_throws_expected_exception() {
+                ExpectedException exception = assertThrows(ExpectedException.class,
+                        () -> OneseoService.buildCalcDtoWithFillEmpty(middleSchoolAchievementReqDto, graduationType));
+
+                assertEquals("예체능 성취점수가 비어있습니다.", exception.getMessage());
+                assertEquals(HttpStatus.BAD_REQUEST, exception.getStatusCode());
+            }
+        }
+
         private MiddleSchoolAchievementReqDto.MiddleSchoolAchievementReqDtoBuilder createDefaultDtoBuilder() {
             return MiddleSchoolAchievementReqDto.builder()
                     .achievement1_1(new ArrayList<>(List.of(1, 1, 1, 1, 1, 1, 1, 1, 1)))


### PR DESCRIPTION
## 개요

예체능 과목이 선택된 상태에서 성취점수를 입력하지 않은 채 임시저장 시 Lambda가 400을 반환하는 버그를 수정합니다.

## 본문

`OneseoTempStorageService`에서 Lambda 점수 계산을 호출할 때 `artsPhysicalSubjects`가 존재하는데 `artsPhysicalAchievement`가 `null` 또는 빈 배열 `[]`인 경우를 검증하지 않아 Lambda가 "과목은 있는데 점수 없음"으로 판단해 400을 반환하고 있었습니다.

임시저장은 미완성 데이터를 허용해야 하므로 에러 대신 Lambda 호출을 생략하고 `calculatedScore`를 `null`로 반환하도록 수정했습니다. 최종 제출(Create/Modify) 경로에서는 동일 조건 발생 시 명확한 에러 메시지를 반환하는 방어 코드를 추가했습니다.

### 변경

- `OneseoTempStorageService.calculateScore()`: `artsPhysicalSubjects` 존재 + `artsPhysicalAchievement` null/빈 배열인 경우 Lambda 호출 생략 → `calculatedScore = null` 반환
- `OneseoService.validationArtsPhysicalAchievement()`: `subjects` 파라미터 추가, 과목 존재 시 빈 배열 검증으로 최종 제출 경로 방어 처리
- `ModifyOneseoService.validationArtsPhysicalAchievement()`: 동일하게 `subjects` 파라미터 추가 및 검증 적용

---

# RCA 룰

r: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)  
c: 웬만하면 반영해 주세요. (Comment)  
a: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)