### PR TITLE
[oneseo] 원서 검색에 수정 요청/승인 기준으로 필터링 할 수 있도록 파라미터 추가

### DIFF
--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/controller/OneseoController.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/controller/OneseoController.java
@@ -11,7 +11,6 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
@@ -98,9 +97,9 @@ public class OneseoController {
             @RequestParam @Min(0) Integer size,
             @RequestParam TestResultTag testResultTag,
             @RequestParam(required = false) ScreeningCategory screeningTag,
-            @Schema(description = "서류 제출 여부") @RequestParam(required = false) YesNo isSubmitted,
+            @RequestParam(required = false) YesNo isSubmitted,
             @RequestParam(name = "keyword", required = false) String keyword,
-            @Schema(description = "수정 요청/승인 원서 필터") @RequestParam(required = false) Boolean requested) {
+            @RequestParam(required = false) Boolean requested) {
         return searchOneseoService.execute(page, size, testResultTag, screeningTag, isSubmitted, keyword, requested);
     }
 

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/controller/OneseoController.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/controller/OneseoController.java
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
@@ -91,15 +92,15 @@ public class OneseoController {
         return CommonApiResponse.success("수정되었습니다.");
     }
 
-    @Operation(summary = "원서 검색", description = "조건을 파라미터로 받아 원서를 검색합니다. requested=true 시 수정 요청/승인된 원서만 반환합니다.")
+    @Operation(summary = "원서 검색", description = "조건을 파라미터로 받아 원서를 검색합니다.")
     @GetMapping("/oneseo/search")
     public SearchOneseosResDto search(@RequestParam @Min(0) Integer page,
             @RequestParam @Min(0) Integer size,
             @RequestParam TestResultTag testResultTag,
             @RequestParam(required = false) ScreeningCategory screeningTag,
-            @RequestParam(required = false) YesNo isSubmitted,
+            @Schema(description = "서류 제출 여부") @RequestParam(required = false) YesNo isSubmitted,
             @RequestParam(name = "keyword", required = false) String keyword,
-            @RequestParam(required = false) Boolean requested) {
+            @Schema(description = "수정 요청/승인 원서 필터") @RequestParam(required = false) Boolean requested) {
         return searchOneseoService.execute(page, size, testResultTag, screeningTag, isSubmitted, keyword, requested);
     }
 

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/controller/OneseoController.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/controller/OneseoController.java
@@ -92,15 +92,16 @@ public class OneseoController {
         return CommonApiResponse.success("수정되었습니다.");
     }
 
-    @Operation(summary = "원서 검색", description = "조건을 파라미터로 받아 원서를 검색합니다.")
+    @Operation(summary = "원서 검색", description = "조건을 파라미터로 받아 원서를 검색합니다. requested=true 시 수정 요청/승인된 원서만 반환합니다.")
     @GetMapping("/oneseo/search")
     public SearchOneseosResDto search(@RequestParam @Min(0) Integer page,
             @RequestParam @Min(0) Integer size,
             @RequestParam TestResultTag testResultTag,
             @RequestParam(required = false) ScreeningCategory screeningTag,
             @Schema(description = "서류 제출 여부") @RequestParam(required = false) YesNo isSubmitted,
-            @RequestParam(name = "keyword", required = false) String keyword) {
-        return searchOneseoService.execute(page, size, testResultTag, screeningTag, isSubmitted, keyword);
+            @RequestParam(name = "keyword", required = false) String keyword,
+            @Schema(description = "수정 요청/승인 원서 필터") @RequestParam(required = false) Boolean requested) {
+        return searchOneseoService.execute(page, size, testResultTag, screeningTag, isSubmitted, keyword, requested);
     }
 
     @Operation(summary = "내 원서 조회", description = "내 원서 정보를 조회합니다. 임시 저장된 원서가 있다면 임시 저장된 원서를 조회합니다.")

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/repository/custom/CustomOneseoRepository.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/repository/custom/CustomOneseoRepository.java
@@ -28,6 +28,7 @@ public interface CustomOneseoRepository {
             ScreeningCategory screening,
             YesNo isSubmitted,
             TestResultTag testResultTag,
+            Boolean requested,
             Pageable pageable);
 
     List<AdmissionTicketsResDto> findAdmissionTickets();

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/repository/custom/impl/CustomOneseoRepositoryImpl.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/repository/custom/impl/CustomOneseoRepositoryImpl.java
@@ -159,8 +159,7 @@ public class CustomOneseoRepositoryImpl implements CustomOneseoRepository {
         if (requested == null || !requested)
             return;
 
-        builder.andAnyOf(oneseo.oneseoEditStatus.eq(OneseoEditStatus.REQUESTED),
-                oneseo.oneseoEditStatus.eq(OneseoEditStatus.APPROVED));
+        builder.and(oneseo.oneseoEditStatus.in(OneseoEditStatus.REQUESTED, OneseoEditStatus.APPROVED));
     }
 
     private void applyKeyword(BooleanBuilder builder, String keyword) {

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/repository/custom/impl/CustomOneseoRepositoryImpl.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/repository/custom/impl/CustomOneseoRepositoryImpl.java
@@ -31,6 +31,7 @@ import team.themoment.hellogsmv3.domain.oneseo.dto.response.AdmissionTicketsResD
 import team.themoment.hellogsmv3.domain.oneseo.dto.response.SearchOneseoResDto;
 import team.themoment.hellogsmv3.domain.oneseo.entity.EntranceTestResult;
 import team.themoment.hellogsmv3.domain.oneseo.entity.Oneseo;
+import team.themoment.hellogsmv3.domain.oneseo.entity.type.OneseoEditStatus;
 import team.themoment.hellogsmv3.domain.oneseo.entity.type.Screening;
 import team.themoment.hellogsmv3.domain.oneseo.entity.type.ScreeningCategory;
 import team.themoment.hellogsmv3.domain.oneseo.entity.type.YesNo;
@@ -69,9 +70,10 @@ public class CustomOneseoRepositoryImpl implements CustomOneseoRepository {
             ScreeningCategory screeningTag,
             YesNo isSubmitted,
             TestResultTag testResultTag,
+            Boolean requested,
             Pageable pageable) {
 
-        BooleanBuilder builder = createBooleanBuilder(keyword, screeningTag, isSubmitted, testResultTag);
+        BooleanBuilder builder = createBooleanBuilder(keyword, screeningTag, isSubmitted, testResultTag, requested);
 
         List<SearchOneseoResDto> oneseos = queryFactory
                 .select(Projections.constructor(SearchOneseoResDto.class,
@@ -140,15 +142,25 @@ public class CustomOneseoRepositoryImpl implements CustomOneseoRepository {
     private BooleanBuilder createBooleanBuilder(String keyword,
             ScreeningCategory screeningTag,
             YesNo isSubmitted,
-            TestResultTag testResultTag) {
+            TestResultTag testResultTag,
+            Boolean requested) {
 
         BooleanBuilder builder = new BooleanBuilder();
         applyKeyword(builder, keyword);
         applyScreeningTag(builder, screeningTag);
         applyIsSubmittedTag(builder, isSubmitted);
         applyTestResultTag(builder, testResultTag);
+        applyRequestedTag(builder, requested);
 
         return builder;
+    }
+
+    private void applyRequestedTag(BooleanBuilder builder, Boolean requested) {
+        if (requested == null || !requested)
+            return;
+
+        builder.andAnyOf(oneseo.oneseoEditStatus.eq(OneseoEditStatus.REQUESTED),
+                oneseo.oneseoEditStatus.eq(OneseoEditStatus.APPROVED));
     }
 
     private void applyKeyword(BooleanBuilder builder, String keyword) {

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/SearchOneseoService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/SearchOneseoService.java
@@ -27,13 +27,15 @@ public class SearchOneseoService {
             TestResultTag testResultTag,
             ScreeningCategory screeningTag,
             YesNo isSubmitted,
-            String keyword) {
+            String keyword,
+            Boolean requested) {
 
         Pageable pageable = PageRequest.of(page, size);
         Page<SearchOneseoResDto> oneseoPage = findOneseoByTagsAndKeyword(testResultTag,
                 screeningTag,
                 isSubmitted,
                 keyword,
+                requested,
                 pageable);
 
         SearchOneseoPageInfoDto infoDto = SearchOneseoPageInfoDto.builder().totalPages(oneseoPage.getTotalPages())
@@ -46,11 +48,13 @@ public class SearchOneseoService {
             ScreeningCategory screeningTag,
             YesNo isSubmitted,
             String keyword,
+            Boolean requested,
             Pageable pageable) {
         return oneseoRepository.findAllByKeywordAndScreeningAndSubmissionStatusAndTestResult(keyword,
                 screeningTag,
                 isSubmitted,
                 testResultTag,
+                requested,
                 pageable);
     }
 }

--- a/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/SearchOneseoServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/SearchOneseoServiceTest.java
@@ -71,6 +71,7 @@ class SearchOneseoServiceTest {
                         screeningTag,
                         isSubmitted,
                         testResultTag,
+                        null,
                         pageable)).willReturn(emptyPage);
             }
 
@@ -78,7 +79,7 @@ class SearchOneseoServiceTest {
             @DisplayName("빈 결과를 반환한다")
             void it_returns_empty_result() {
                 SearchOneseosResDto result = searchOneseoService
-                        .execute(page, size, testResultTag, screeningTag, isSubmitted, keyword);
+                        .execute(page, size, testResultTag, screeningTag, isSubmitted, keyword, null);
 
                 assertEquals(0, result.info().totalElements());
                 assertEquals(0, result.info().totalPages());
@@ -114,6 +115,7 @@ class SearchOneseoServiceTest {
                         screeningTag,
                         isSubmitted,
                         testResultTag,
+                        null,
                         pageable)).willReturn(oneseoPage);
             }
 
@@ -121,7 +123,7 @@ class SearchOneseoServiceTest {
             @DisplayName("적절한 데이터를 반환한다")
             void it_returns_filtered_results() {
                 SearchOneseosResDto result = searchOneseoService
-                        .execute(page, size, testResultTag, screeningTag, isSubmitted, keyword);
+                        .execute(page, size, testResultTag, screeningTag, isSubmitted, keyword, null);
 
                 SearchOneseoPageInfoDto searchOneseoPageInfoDto = result.info();
                 assertEquals(1, searchOneseoPageInfoDto.totalElements());

--- a/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/SearchOneseoServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/SearchOneseoServiceTest.java
@@ -147,6 +147,48 @@ class SearchOneseoServiceTest {
                 assertEquals(entranceTestResult.getSecondTestPassYn(), searchOneseoResDto.secondTestPassYn());
             }
         }
+
+        @Nested
+        @DisplayName("requested=true가 주어진 경우")
+        class Context_with_requested_true {
+
+            private Member member;
+            private Oneseo oneseo;
+            private OneseoPrivacyDetail oneseoPrivacyDetail;
+            private EntranceTestResult entranceTestResult;
+
+            @BeforeEach
+            void setUp() {
+                Pageable pageable = PageRequest.of(page, size);
+                member = buildMember();
+                oneseo = buildOneseo();
+                oneseoPrivacyDetail = buildOneseoPrivacyDetail();
+                entranceTestResult = buildEntranceTestResult();
+
+                SearchOneseoResDto searchOneseoResDto = buildSearchOneseoDto(member,
+                        oneseo,
+                        oneseoPrivacyDetail,
+                        entranceTestResult);
+                Page<SearchOneseoResDto> oneseoPage = new PageImpl<>(List.of(searchOneseoResDto), pageable, 1);
+
+                given(oneseoRepository.findAllByKeywordAndScreeningAndSubmissionStatusAndTestResult(keyword,
+                        screeningTag,
+                        isSubmitted,
+                        testResultTag,
+                        true,
+                        pageable)).willReturn(oneseoPage);
+            }
+
+            @Test
+            @DisplayName("수정 요청/승인 필터가 repository로 올바르게 전달된다")
+            void it_passes_requested_filter_to_repository() {
+                SearchOneseosResDto result = searchOneseoService
+                        .execute(page, size, testResultTag, screeningTag, isSubmitted, keyword, true);
+
+                assertEquals(1, result.info().totalElements());
+                assertEquals(1, result.oneseos().size());
+            }
+        }
     }
 
     private OneseoPrivacyDetail buildOneseoPrivacyDetail() {


### PR DESCRIPTION
## 개요

원서 검색 API(`GET /oneseo/v3/oneseo/search`)에 `requested` 쿼리 파라미터를 추가했습니다. 어드민에서 수정 권한을 요청하거나 승인된 원서(`REQUESTED`, `APPROVED`)를 한번에 필터링하여 조회할 수 있습니다.

## 본문

기존 원서 검색 API는 `oneseoEditStatus`를 응답에 포함하여 반환하고 있었지만, 해당 상태로 필터링하는 기능은 없었습니다. 어드민이 수정 요청/승인된 원서를 별도로 확인해야 하는 요구사항에 따라 `requested` 파라미터를 추가했습니다.

- `requested=true`: `oneseoEditStatus`가 `REQUESTED` 또는 `APPROVED`인 원서만 반환
- `requested` 미입력 또는 `false`: 기존과 동일하게 전체 반환

### 변경

- `CustomOneseoRepository` — `findAllByKeywordAndScreeningAndSubmissionStatusAndTestResult()` 시그니처에 `Boolean requested` 파라미터 추가
- `CustomOneseoRepositoryImpl` — `applyRequestedTag()` 헬퍼 메서드 추가, `requested=true` 시 `REQUESTED | APPROVED` OR 조건 적용
- `SearchOneseoService` — `execute()` 및 `findOneseoByTagsAndKeyword()`에 `requested` 파라미터 전달
- `OneseoController` — `search()` 엔드포인트에 `@RequestParam(required = false) Boolean requested` 추가
- `SearchOneseoServiceTest` — 기존 테스트에 `requested=null` 인자 추가

---

# RCA 룰

r: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)  
c: 웬만하면 반영해 주세요. (Comment)  
a: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)
