### PR TITLE
[oneseo] 임시저장 시 achievement1_1 필드 누락 수정

### DIFF
--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/dto/response/MiddleSchoolAchievementResDto.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/dto/response/MiddleSchoolAchievementResDto.java
@@ -6,7 +6,7 @@ import java.util.List;
 import lombok.Builder;
 
 @Builder
-public record MiddleSchoolAchievementResDto(List<Integer> achievement1_2, List<Integer> achievement2_1,
+public record MiddleSchoolAchievementResDto(List<Integer> achievement1_1, List<Integer> achievement1_2, List<Integer> achievement2_1,
         List<Integer> achievement2_2, List<Integer> achievement3_1, List<Integer> achievement3_2,
         List<String> generalSubjects, List<String> newSubjects, List<Integer> artsPhysicalAchievement,
         List<String> artsPhysicalSubjects, List<Integer> absentDays, Integer absentDaysCount,

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/dto/response/MiddleSchoolAchievementResDto.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/dto/response/MiddleSchoolAchievementResDto.java
@@ -6,10 +6,10 @@ import java.util.List;
 import lombok.Builder;
 
 @Builder
-public record MiddleSchoolAchievementResDto(List<Integer> achievement1_1, List<Integer> achievement1_2, List<Integer> achievement2_1,
-        List<Integer> achievement2_2, List<Integer> achievement3_1, List<Integer> achievement3_2,
-        List<String> generalSubjects, List<String> newSubjects, List<Integer> artsPhysicalAchievement,
-        List<String> artsPhysicalSubjects, List<Integer> absentDays, Integer absentDaysCount,
-        List<Integer> attendanceDays, List<Integer> volunteerTime, String liberalSystem, String freeSemester,
-        BigDecimal gedAvgScore) {
+public record MiddleSchoolAchievementResDto(List<Integer> achievement1_1, List<Integer> achievement1_2,
+        List<Integer> achievement2_1, List<Integer> achievement2_2, List<Integer> achievement3_1,
+        List<Integer> achievement3_2, List<String> generalSubjects, List<String> newSubjects,
+        List<Integer> artsPhysicalAchievement, List<String> artsPhysicalSubjects, List<Integer> absentDays,
+        Integer absentDaysCount, List<Integer> attendanceDays, List<Integer> volunteerTime, String liberalSystem,
+        String freeSemester, BigDecimal gedAvgScore) {
 }

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/OneseoTempStorageService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/OneseoTempStorageService.java
@@ -74,7 +74,8 @@ public class OneseoTempStorageService {
         List<Integer> absentDays = middleSchoolAchievement.absentDays();
         List<Integer> attendanceDays = middleSchoolAchievement.attendanceDays();
 
-        return MiddleSchoolAchievementResDto.builder().achievement1_1(middleSchoolAchievement.achievement1_1()).achievement1_2(middleSchoolAchievement.achievement1_2())
+        return MiddleSchoolAchievementResDto.builder().achievement1_1(middleSchoolAchievement.achievement1_1())
+                .achievement1_2(middleSchoolAchievement.achievement1_2())
                 .achievement2_1(middleSchoolAchievement.achievement2_1())
                 .achievement2_2(middleSchoolAchievement.achievement2_2())
                 .achievement3_1(middleSchoolAchievement.achievement3_1())

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/OneseoTempStorageService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/OneseoTempStorageService.java
@@ -74,7 +74,7 @@ public class OneseoTempStorageService {
         List<Integer> absentDays = middleSchoolAchievement.absentDays();
         List<Integer> attendanceDays = middleSchoolAchievement.attendanceDays();
 
-        return MiddleSchoolAchievementResDto.builder().achievement1_2(middleSchoolAchievement.achievement1_2())
+        return MiddleSchoolAchievementResDto.builder().achievement1_1(middleSchoolAchievement.achievement1_1()).achievement1_2(middleSchoolAchievement.achievement1_2())
                 .achievement2_1(middleSchoolAchievement.achievement2_1())
                 .achievement2_2(middleSchoolAchievement.achievement2_2())
                 .achievement3_1(middleSchoolAchievement.achievement3_1())

--- a/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/OneseoTempStorageServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/OneseoTempStorageServiceTest.java
@@ -61,7 +61,8 @@ public class OneseoTempStorageServiceTest {
                 .relationshipWithGuardian("모").schoolName("금호중앙중학교").schoolAddress("광주광역시 북구 운암2동 금호로 100")
                 .schoolTeacherName("김선생").schoolTeacherPhoneNumber("01012345678")
                 .profileImg("https://example.com/image.jpg")
-                .middleSchoolAchievement(MiddleSchoolAchievementReqDto.builder().achievement1_2(null)
+                .middleSchoolAchievement(MiddleSchoolAchievementReqDto.builder()
+                        .achievement1_1(List.of(3, 4, 5, 3, 4, 5, 3, 4)).achievement1_2(null)
                         .achievement2_1(List.of(4, 5, 3, 5, 4, 5, 3, 5, 2))
                         .achievement2_2(List.of(5, 2, 5, 5, 4, 1, 5, 5, 0))
                         .achievement3_1(List.of(3, 5, 3, 5, 1, 3, 5, 2, 0)).achievement3_2(null)
@@ -127,6 +128,8 @@ public class OneseoTempStorageServiceTest {
                     assertEquals(reqDto.schoolTeacherPhoneNumber(), resDto.privacyDetail().schoolTeacherPhoneNumber());
                     assertEquals(reqDto.profileImg(), resDto.privacyDetail().profileImg());
                     assertEquals(reqDto.studentNumber(), resDto.privacyDetail().studentNumber());
+                    assertEquals(reqDto.middleSchoolAchievement().achievement1_1(),
+                            resDto.middleSchoolAchievement().achievement1_1());
                     assertEquals(reqDto.middleSchoolAchievement().achievement1_2(),
                             resDto.middleSchoolAchievement().achievement1_2());
                     assertEquals(reqDto.middleSchoolAchievement().achievement2_1(),


### PR DESCRIPTION
## 개요

임시저장 후 불러올 때 1학년 1학기 성적(`achievement1_1`)이 항상 누락되는 버그를 수정합니다.

## 본문

`MiddleSchoolAchievementResDto`에 `achievement1_1` 필드가 선언되지 않았고, `OneseoTempStorageService`의 builder에서도 해당 필드를 설정하지 않아 임시저장 캐시에 저장 및 반환 시 1학년 1학기 성적이 유실되었습니다.

### 변경

- `MiddleSchoolAchievementResDto` — `achievement1_1` 필드 추가
- `OneseoTempStorageService#buildMiddleSchoolAchievementResDto` — builder에 `achievement1_1` 설정 추가

---

# RCA 룰

r: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)  
c: 웬만하면 반영해 주세요. (Comment)  
a: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)