### PR TITLE
[global] 커밋 해시 8자리 설정 및 push 스텝 추가

### DIFF
--- a/.agents/skills/review-pr/SKILL.md
+++ b/.agents/skills/review-pr/SKILL.md
@@ -2,7 +2,7 @@
 name: review-pr
 description: Collect PR review comments, critically assess each one against project conventions, auto-apply valid ones, post refutation replies for invalid ones, and prompt for partial ones. Replaces resolve-pr-comments.
 compatibility: Requires git, gh (GitHub CLI), and jq
-allowed-tools: Bash(bash *get-pr-data.sh:*), Bash(gh api:*), Bash(gh pr view:*), Bash(gh repo:*), Bash(git add:*), Bash(git commit:*), Bash(git log:*), Bash(git rev-parse:*), Bash(rm:*), Edit, Read
+allowed-tools: Bash(bash *get-pr-data.sh:*), Bash(gh api:*), Bash(gh pr view:*), Bash(gh repo:*), Bash(git add:*), Bash(git commit:*), Bash(git log:*), Bash(git push:*), Bash(git rev-parse:*), Bash(rm:*), Edit, Read
 ---
 
 ## Step 1 — Collect PR Data
@@ -52,7 +52,7 @@ Always cite a specific source in the rationale (e.g. `CLAUDE.md §Logging Style`
 3. If the changes have not been committed yet, commit them
 4. Record the short commit hash for use in Step 5:
    ```bash
-   git rev-parse --short HEAD
+   git rev-parse --short=7 HEAD
    ```
 
 On failure: record the reason and fall back to PARTIAL.
@@ -88,7 +88,15 @@ Accept? (y / n / s = skip for now)
 | 3 | alice | Baz.kt:56 | ⚠️ PARTIAL | - | PENDING |
 ```
 
-## Step 5 — Post GitHub Replies
+## Step 5 — Push Commits
+
+If any VALID fixes were committed in Step 3, push them before posting replies so the referenced commit hashes are visible on GitHub:
+
+```bash
+git push
+```
+
+## Step 6 — Post GitHub Replies
 
 Post an inline reply for each comment. Always quote `path` and `comment_id` to prevent shell injection.
 
@@ -99,7 +107,7 @@ gh api "repos/<owner>/<repo>/pulls/<pr_number>/comments/<comment_id>/replies" \
 
 For reply body templates, read `references/reply-formats.md`.
 
-## Step 6 — Cleanup
+## Step 7 — Cleanup
 
 ```bash
 rm -rf .pr-tmp

--- a/.agents/skills/review-pr/SKILL.md
+++ b/.agents/skills/review-pr/SKILL.md
@@ -2,7 +2,7 @@
 name: review-pr
 description: Collect PR review comments, critically assess each one against project conventions, auto-apply valid ones, post refutation replies for invalid ones, and prompt for partial ones. Replaces resolve-pr-comments.
 compatibility: Requires git, gh (GitHub CLI), and jq
-allowed-tools: Bash(bash *get-pr-data.sh:*), Bash(gh api:*), Bash(gh pr view:*), Bash(gh repo:*), Bash(git add:*), Bash(git commit:*), Bash(git log:*), Bash(git push:*), Bash(git rev-parse:*), Bash(rm:*), Edit, Read
+allowed-tools: Bash(bash *get-pr-data.sh:*), Bash(gh api:*), Bash(gh pr view:*), Bash(gh repo:*), Bash(git add:*), Bash(git commit:*), Bash(git log:*), Bash(git push:*), Bash(git rev-parse:*), Bash(rm:*), Edit, Read, AskUserQuestion
 ---
 
 ## Step 1 — Collect PR Data
@@ -50,7 +50,7 @@ Always cite a specific source in the rationale (e.g. `CLAUDE.md §Logging Style`
 1. Read the target file with the Read tool
 2. Apply the reviewer's concern with the Edit tool
 3. If the changes have not been committed yet, commit them
-4. Record the short commit hash for use in Step 5:
+4. Record the short commit hash for use in Step 4 and Step 6:
    ```bash
    git rev-parse --short=7 HEAD
    ```
@@ -59,7 +59,7 @@ On failure: record the reason and fall back to PARTIAL.
 
 ### INVALID → Skip
 
-Do not modify any code. Record the refutation rationale for Step 5.
+Do not modify any code. Record the refutation rationale for Step 6.
 
 ### PARTIAL → Confirm with AskUserQuestion
 

--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -2,7 +2,7 @@
 name: review-pr
 description: Collect PR review comments, critically assess each one against project conventions, auto-apply valid ones, post refutation replies for invalid ones, and prompt for partial ones. Replaces resolve-pr-comments.
 disable-model-invocation: true
-allowed-tools: Bash(bash *get-pr-data.sh:*), Bash(gh api:*), Bash(gh pr view:*), Bash(gh repo:*), Bash(git add:*), Bash(git commit:*), Bash(git log:*), Bash(git rev-parse:*), Bash(rm:*), Edit, Read, AskUserQuestion
+allowed-tools: Bash(bash *get-pr-data.sh:*), Bash(gh api:*), Bash(gh pr view:*), Bash(gh repo:*), Bash(git add:*), Bash(git commit:*), Bash(git log:*), Bash(git push:*), Bash(git rev-parse:*), Bash(rm:*), Edit, Read, AskUserQuestion
 ---
 
 ## Step 1 — Collect PR Data
@@ -62,7 +62,7 @@ Always cite a specific source in the rationale (e.g. `CLAUDE.md §Logging Style`
 3. If the changes have not been committed yet, commit them
 4. Record the short commit hash for use in Step 5:
    ```bash
-   git rev-parse --short HEAD
+   git rev-parse --short=7 HEAD
    ```
 
 On failure: record the reason and fall back to PARTIAL.
@@ -98,7 +98,15 @@ Accept? (y / n / s = skip for now)
 | 3 | alice | Baz.kt:56 | ⚠️ PARTIAL | - | PENDING |
 ```
 
-## Step 5 — Post GitHub Replies
+## Step 5 — Push Commits
+
+If any VALID fixes were committed in Step 3, push them before posting replies so the referenced commit hashes are visible on GitHub:
+
+```bash
+git push
+```
+
+## Step 6 — Post GitHub Replies
 
 Post an inline reply for each comment. Always quote `path` and `comment_id` to prevent shell injection.
 
@@ -109,7 +117,7 @@ gh api "repos/$REPO/pulls/$PR_NUMBER/comments/<comment_id>/replies" \
 
 For reply body templates, read `${CLAUDE_SKILL_DIR}/references/reply-formats.md`.
 
-## Step 6 — Cleanup
+## Step 7 — Cleanup
 
 ```bash
 rm -rf .pr-tmp

--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -60,7 +60,7 @@ Always cite a specific source in the rationale (e.g. `CLAUDE.md §Logging Style`
 1. Read the target file with the Read tool
 2. Apply the reviewer's concern with the Edit tool
 3. If the changes have not been committed yet, commit them
-4. Record the short commit hash for use in Step 5:
+4. Record the short commit hash for use in Step 4 and Step 6:
    ```bash
    git rev-parse --short=7 HEAD
    ```
@@ -69,7 +69,7 @@ On failure: record the reason and fall back to PARTIAL.
 
 ### INVALID → Skip
 
-Do not modify any code. Record the refutation rationale for Step 5.
+Do not modify any code. Record the refutation rationale for Step 6.
 
 ### PARTIAL → Confirm with AskUserQuestion
 


### PR DESCRIPTION
## 개요

`review-pr` 스킬의 두 가지 문제를 수정했습니다. 인라인 코멘트 게시 전 `git push`가 누락되어 GitHub에서 커밋 해시를 확인할 수 없었던 문제와, 커밋 해시가 8자리로 출력되던 문제를 수정했습니다.

## 본문

### 변경

- `.agents/skills/review-pr/SKILL.md`, `.claude/skills/review-pr/SKILL.md`
  - `allowed-tools`에 `Bash(git push:*)` 추가
  - `git rev-parse --short` → `--short=7`로 수정하여 커밋 해시를 정확히 7자리로 출력
  - Step 5 "Push Commits" 신규 삽입 — VALID 수정 커밋이 존재할 경우 `git push` 후 인라인 코멘트 게시
  - 기존 Step 5·6을 각각 Step 6·7로 번호 조정

---

# RCA 룰

r: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)  
c: 웬만하면 반영해 주세요. (Comment)  
a: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)
