### PR TITLE
[oneseo] 인적사항 수정 API를 멤버 엔티티 기반으로 변경

### DIFF
--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/controller/OneseoController.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/controller/OneseoController.java
@@ -193,15 +193,15 @@ public class OneseoController {
     @PatchMapping("/personal-info/me")
     public CommonApiResponse modifyMyPersonalInfo(@RequestBody @Valid ModifyPersonalInfoReqDto reqDto,
             @AuthRequest Long memberId) {
-        modifyPersonalInfoService.execute(reqDto, memberId);
+        modifyPersonalInfoService.execute(reqDto, memberId, true);
         return CommonApiResponse.success("수정되었습니다.");
     }
 
-    @Operation(summary = "인적사항 수정", description = "관리자가 맴버 id로 회원의 인적사항(이름, 생년월일, 성별)을 수정합니다.")
+    @Operation(summary = "인적사항 수정", description = "관리자가 멤버 id로 회원의 인적사항(이름, 생년월일, 성별)을 수정합니다.")
     @PatchMapping("/personal-info/{memberId}")
     public CommonApiResponse modifyPersonalInfo(@RequestBody @Valid ModifyPersonalInfoReqDto reqDto,
             @PathVariable Long memberId) {
-        modifyPersonalInfoService.execute(reqDto, memberId);
+        modifyPersonalInfoService.execute(reqDto, memberId, false);
         return CommonApiResponse.success("수정되었습니다.");
     }
 }

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/controller/OneseoController.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/controller/OneseoController.java
@@ -189,10 +189,18 @@ public class OneseoController {
         return CommonApiResponse.success("원서가 수정되었습니다.");
     }
 
-    @Operation(summary = "인적사항 수정", description = "내 원서의 인적사항(이름, 생년월일, 성별, 주소, 보호자 정보, 학교 정보 등)을 수정합니다.")
+    @Operation(summary = "내 인적사항 수정", description = "회원이 자신의 인적사항(이름, 생년월일, 성별)을 수정합니다.")
     @PatchMapping("/personal-info/me")
-    public CommonApiResponse modifyPersonalInfo(@RequestBody @Valid ModifyPersonalInfoReqDto reqDto,
+    public CommonApiResponse modifyMyPersonalInfo(@RequestBody @Valid ModifyPersonalInfoReqDto reqDto,
             @AuthRequest Long memberId) {
+        modifyPersonalInfoService.execute(reqDto, memberId);
+        return CommonApiResponse.success("수정되었습니다.");
+    }
+
+    @Operation(summary = "인적사항 수정", description = "관리자가 맴버 id로 회원의 인적사항(이름, 생년월일, 성별)을 수정합니다.")
+    @PatchMapping("/personal-info/{memberId}")
+    public CommonApiResponse modifyPersonalInfo(@RequestBody @Valid ModifyPersonalInfoReqDto reqDto,
+            @PathVariable Long memberId) {
         modifyPersonalInfoService.execute(reqDto, memberId);
         return CommonApiResponse.success("수정되었습니다.");
     }

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/dto/request/ModifyPersonalInfoReqDto.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/dto/request/ModifyPersonalInfoReqDto.java
@@ -7,28 +7,12 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Pattern;
 import lombok.Builder;
 import team.themoment.hellogsmv3.domain.member.entity.type.Sex;
-import team.themoment.hellogsmv3.domain.oneseo.entity.type.GraduationType;
 
 @Builder
 public record ModifyPersonalInfoReqDto(@Schema(description = "이름", defaultValue = "홍길동") @NotBlank String name,
         @Schema(description = "생년월일", defaultValue = "2009-01-01") @NotNull @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd") LocalDate birth,
         @Schema(description = "성별", defaultValue = "MALE", allowableValues = {
-                "MALE", "FEMALE"}) @NotNull Sex sex,
-        @Schema(description = "보호자 이름", defaultValue = "김보호") @NotBlank String guardianName,
-        @Schema(description = "보호자 전화번호", defaultValue = "01000000000") @NotBlank @Pattern(regexp = "^0(?:\\d|\\d{2})(?:\\d{3}|\\d{4})\\d{4}$", message = "유효한 전화번호가 아닙니다.") String guardianPhoneNumber,
-        @Schema(description = "보호자와 관계", defaultValue = "모") @NotBlank String relationshipWithGuardian,
-        @Schema(description = "증명사진 URL", defaultValue = "https://abc.com") @NotBlank @Pattern(regexp = "^https://[^\\s/$.?#].[^\\s]*$", message = "유효한 이미지 URL이 아닙니다.") String profileImg,
-        @Schema(description = "주소", defaultValue = "광주광역시 광산구 송정동 상무대로 312") @NotBlank String address,
-        @Schema(description = "상세주소", defaultValue = "101동 1001호") @NotBlank String detailAddress,
-        @Schema(description = "지원자 졸업상태", defaultValue = "CANDIDATE", allowableValues = {"CANDIDATE", "GED",
-                "GRADUATE"}) @NotNull GraduationType graduationType,
-        @Schema(description = "담임선생님 이름", defaultValue = "김선생") String schoolTeacherName,
-        @Schema(description = "담임선생님 전화번호", nullable = true, defaultValue = "01000000000") @Pattern(regexp = "^0(?:\\d|\\d{2})(?:\\d{3}|\\d{4})\\d{4}$", message = "유효한 전화번호가 아닙니다.") String schoolTeacherPhoneNumber,
-        @Schema(description = "중학교 이름", nullable = true, defaultValue = "금호중앙중학교") String schoolName,
-        @Schema(description = "중학교 주소", nullable = true, defaultValue = "광주광역시 북구 운암2동 금호로 100") String schoolAddress,
-        @Schema(description = "중학교 졸업년월", defaultValue = "2006-03") @Pattern(regexp = "^\\d{4}-(0[1-9]|1[0-2])$") @NotNull String graduationDate,
-        @Schema(description = "학생 번호", defaultValue = "30508") @Pattern(regexp = "^\\d{5}$") String studentNumber){
+                "MALE", "FEMALE"}) @NotNull Sex sex){
 }

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyPersonalInfoService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyPersonalInfoService.java
@@ -1,56 +1,24 @@
 package team.themoment.hellogsmv3.domain.oneseo.service;
 
 import org.springframework.cache.annotation.CacheEvict;
-import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
 import team.themoment.hellogsmv3.domain.member.entity.Member;
+import team.themoment.hellogsmv3.domain.member.service.MemberService;
 import team.themoment.hellogsmv3.domain.oneseo.dto.request.ModifyPersonalInfoReqDto;
-import team.themoment.hellogsmv3.domain.oneseo.entity.Oneseo;
-import team.themoment.hellogsmv3.domain.oneseo.entity.OneseoPrivacyDetail;
-import team.themoment.hellogsmv3.domain.oneseo.entity.type.GraduationType;
-import team.themoment.hellogsmv3.domain.oneseo.repository.OneseoPrivacyDetailRepository;
-import team.themoment.sdk.exception.ExpectedException;
 
 @Service
 @RequiredArgsConstructor
 public class ModifyPersonalInfoService {
 
-    private final OneseoService oneseoService;
-    private final OneseoPrivacyDetailRepository oneseoPrivacyDetailRepository;
+    private final MemberService memberService;
 
     @Transactional
     @CacheEvict(value = OneseoService.ONESEO_CACHE_VALUE, key = "#memberId")
     public void execute(ModifyPersonalInfoReqDto reqDto, Long memberId) {
-
-        Oneseo oneseo = oneseoService.findWithMemberByMemberIdOrThrow(memberId);
-
-        OneseoService.isBeforeFirstTest(oneseo.getEntranceTestResult().getFirstTestPassYn());
-
-        if (reqDto.graduationType() == GraduationType.CANDIDATE
-                && (isBlank(reqDto.schoolTeacherName()) || isBlank(reqDto.schoolTeacherPhoneNumber())
-                        || isBlank(reqDto.schoolName()) || isBlank(reqDto.schoolAddress()))) {
-            throw new ExpectedException("중학교 졸업예정인 지원자는 현재 재학 중인 중학교 정보를 필수로 입력해야 합니다.", HttpStatus.BAD_REQUEST);
-        }
-
-        Member member = oneseo.getMember();
+        Member member = memberService.findByIdForUpdateOrThrow(memberId);
         member.modifyMember(reqDto.name(), reqDto.birth(), member.getPhoneNumber(), reqDto.sex());
-
-        OneseoPrivacyDetail updated = OneseoPrivacyDetail.builder().id(oneseo.getId()).oneseo(oneseo)
-                .graduationType(reqDto.graduationType()).graduationDate(reqDto.graduationDate())
-                .address(reqDto.address()).detailAddress(reqDto.detailAddress()).profileImg(reqDto.profileImg())
-                .guardianName(reqDto.guardianName()).guardianPhoneNumber(reqDto.guardianPhoneNumber())
-                .relationshipWithGuardian(reqDto.relationshipWithGuardian()).schoolName(reqDto.schoolName())
-                .schoolAddress(reqDto.schoolAddress()).schoolTeacherName(reqDto.schoolTeacherName())
-                .schoolTeacherPhoneNumber(reqDto.schoolTeacherPhoneNumber()).studentNumber(reqDto.studentNumber())
-                .build();
-
-        oneseoPrivacyDetailRepository.save(updated);
-    }
-
-    private boolean isBlank(String s) {
-        return s == null || s.isBlank();
     }
 }

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyPersonalInfoService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyPersonalInfoService.java
@@ -6,19 +6,25 @@ import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
 import team.themoment.hellogsmv3.domain.member.entity.Member;
-import team.themoment.hellogsmv3.domain.member.service.MemberService;
 import team.themoment.hellogsmv3.domain.oneseo.dto.request.ModifyPersonalInfoReqDto;
+import team.themoment.hellogsmv3.domain.oneseo.entity.Oneseo;
 
 @Service
 @RequiredArgsConstructor
 public class ModifyPersonalInfoService {
 
-    private final MemberService memberService;
+    private final OneseoService oneseoService;
 
     @Transactional
     @CacheEvict(value = OneseoService.ONESEO_CACHE_VALUE, key = "#memberId")
-    public void execute(ModifyPersonalInfoReqDto reqDto, Long memberId) {
-        Member member = memberService.findByIdForUpdateOrThrow(memberId);
+    public void execute(ModifyPersonalInfoReqDto reqDto, Long memberId, boolean checkFirstTest) {
+        Oneseo oneseo = oneseoService.findWithMemberByMemberIdOrThrow(memberId);
+
+        if (checkFirstTest) {
+            OneseoService.isBeforeFirstTest(oneseo.getEntranceTestResult().getFirstTestPassYn());
+        }
+
+        Member member = oneseo.getMember();
         member.modifyMember(reqDto.name(), reqDto.birth(), member.getPhoneNumber(), reqDto.sex());
     }
 }

--- a/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyPersonalInfoServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyPersonalInfoServiceTest.java
@@ -15,15 +15,17 @@ import org.springframework.http.HttpStatus;
 
 import team.themoment.hellogsmv3.domain.member.entity.Member;
 import team.themoment.hellogsmv3.domain.member.entity.type.Sex;
-import team.themoment.hellogsmv3.domain.member.service.MemberService;
 import team.themoment.hellogsmv3.domain.oneseo.dto.request.ModifyPersonalInfoReqDto;
+import team.themoment.hellogsmv3.domain.oneseo.entity.EntranceTestResult;
+import team.themoment.hellogsmv3.domain.oneseo.entity.Oneseo;
+import team.themoment.hellogsmv3.domain.oneseo.entity.type.YesNo;
 import team.themoment.sdk.exception.ExpectedException;
 
 @DisplayName("ModifyPersonalInfoService 클래스의")
 class ModifyPersonalInfoServiceTest {
 
     @Mock
-    private MemberService memberService;
+    private OneseoService oneseoService;
 
     @InjectMocks
     private ModifyPersonalInfoService modifyPersonalInfoService;
@@ -44,15 +46,22 @@ class ModifyPersonalInfoServiceTest {
         }
 
         @Nested
-        @DisplayName("유효한 회원 ID와 인적사항 데이터가 주어진 경우")
-        class Context_with_valid_member_id_and_data {
+        @DisplayName("1차 전형 결과가 산출되지 않은 경우")
+        class Context_with_first_test_not_announced {
 
             private Member member;
+            private Oneseo oneseo;
 
             @BeforeEach
             void setUp() {
                 member = mock(Member.class);
-                given(memberService.findByIdForUpdateOrThrow(memberId)).willReturn(member);
+                oneseo = mock(Oneseo.class);
+                EntranceTestResult entranceTestResult = mock(EntranceTestResult.class);
+
+                given(oneseoService.findWithMemberByMemberIdOrThrow(memberId)).willReturn(oneseo);
+                given(oneseo.getMember()).willReturn(member);
+                given(oneseo.getEntranceTestResult()).willReturn(entranceTestResult);
+                given(entranceTestResult.getFirstTestPassYn()).willReturn(null);
             }
 
             @Test
@@ -60,7 +69,59 @@ class ModifyPersonalInfoServiceTest {
             void it_modifies_member_personal_info() {
                 ModifyPersonalInfoReqDto reqDto = buildReqDto("홍길동", LocalDate.of(2009, 1, 1), Sex.MALE);
 
-                modifyPersonalInfoService.execute(reqDto, memberId);
+                modifyPersonalInfoService.execute(reqDto, memberId, true);
+
+                verify(member).modifyMember("홍길동", LocalDate.of(2009, 1, 1), member.getPhoneNumber(), Sex.MALE);
+            }
+        }
+
+        @Nested
+        @DisplayName("1차 전형 결과가 산출된 후 일반 사용자가 수정을 시도하는 경우")
+        class Context_with_first_test_announced {
+
+            @BeforeEach
+            void setUp() {
+                Oneseo oneseo = mock(Oneseo.class);
+                EntranceTestResult entranceTestResult = mock(EntranceTestResult.class);
+
+                given(oneseoService.findWithMemberByMemberIdOrThrow(memberId)).willReturn(oneseo);
+                given(oneseo.getEntranceTestResult()).willReturn(entranceTestResult);
+                given(entranceTestResult.getFirstTestPassYn()).willReturn(YesNo.YES);
+            }
+
+            @Test
+            @DisplayName("ExpectedException을 던진다")
+            void it_throws_expected_exception() {
+                ModifyPersonalInfoReqDto reqDto = buildReqDto("홍길동", LocalDate.of(2009, 1, 1), Sex.MALE);
+
+                ExpectedException exception = assertThrows(ExpectedException.class,
+                        () -> modifyPersonalInfoService.execute(reqDto, memberId, true));
+
+                assertEquals(HttpStatus.FORBIDDEN, exception.getStatusCode());
+            }
+        }
+
+        @Nested
+        @DisplayName("관리자가 1차 전형 결과 산출 이후 수정을 시도하는 경우")
+        class Context_with_admin_after_first_test {
+
+            private Member member;
+
+            @BeforeEach
+            void setUp() {
+                member = mock(Member.class);
+                Oneseo oneseo = mock(Oneseo.class);
+
+                given(oneseoService.findWithMemberByMemberIdOrThrow(memberId)).willReturn(oneseo);
+                given(oneseo.getMember()).willReturn(member);
+            }
+
+            @Test
+            @DisplayName("검증 없이 회원 정보를 수정한다")
+            void it_modifies_member_personal_info_without_check() {
+                ModifyPersonalInfoReqDto reqDto = buildReqDto("홍길동", LocalDate.of(2009, 1, 1), Sex.MALE);
+
+                modifyPersonalInfoService.execute(reqDto, memberId, false);
 
                 verify(member).modifyMember("홍길동", LocalDate.of(2009, 1, 1), member.getPhoneNumber(), Sex.MALE);
             }
@@ -72,8 +133,8 @@ class ModifyPersonalInfoServiceTest {
 
             @BeforeEach
             void setUp() {
-                doThrow(new ExpectedException("존재하지 않는 지원자입니다. member ID: " + memberId, HttpStatus.NOT_FOUND))
-                        .when(memberService).findByIdForUpdateOrThrow(memberId);
+                given(oneseoService.findWithMemberByMemberIdOrThrow(memberId)).willThrow(
+                        new ExpectedException("존재하지 않는 지원자입니다. member ID: " + memberId, HttpStatus.NOT_FOUND));
             }
 
             @Test
@@ -82,7 +143,7 @@ class ModifyPersonalInfoServiceTest {
                 ModifyPersonalInfoReqDto reqDto = buildReqDto("홍길동", LocalDate.of(2009, 1, 1), Sex.MALE);
 
                 ExpectedException exception = assertThrows(ExpectedException.class,
-                        () -> modifyPersonalInfoService.execute(reqDto, memberId));
+                        () -> modifyPersonalInfoService.execute(reqDto, memberId, true));
 
                 assertEquals("존재하지 않는 지원자입니다. member ID: " + memberId, exception.getMessage());
                 assertEquals(HttpStatus.NOT_FOUND, exception.getStatusCode());

--- a/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyPersonalInfoServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyPersonalInfoServiceTest.java
@@ -1,11 +1,8 @@
 package team.themoment.hellogsmv3.domain.oneseo.service;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.*;
-import static team.themoment.hellogsmv3.domain.oneseo.entity.type.GraduationType.*;
-import static team.themoment.hellogsmv3.domain.oneseo.entity.type.YesNo.YES;
 
 import java.time.LocalDate;
 
@@ -18,21 +15,15 @@ import org.springframework.http.HttpStatus;
 
 import team.themoment.hellogsmv3.domain.member.entity.Member;
 import team.themoment.hellogsmv3.domain.member.entity.type.Sex;
+import team.themoment.hellogsmv3.domain.member.service.MemberService;
 import team.themoment.hellogsmv3.domain.oneseo.dto.request.ModifyPersonalInfoReqDto;
-import team.themoment.hellogsmv3.domain.oneseo.entity.EntranceTestResult;
-import team.themoment.hellogsmv3.domain.oneseo.entity.Oneseo;
-import team.themoment.hellogsmv3.domain.oneseo.entity.OneseoPrivacyDetail;
-import team.themoment.hellogsmv3.domain.oneseo.entity.type.GraduationType;
-import team.themoment.hellogsmv3.domain.oneseo.repository.OneseoPrivacyDetailRepository;
 import team.themoment.sdk.exception.ExpectedException;
 
 @DisplayName("ModifyPersonalInfoService 클래스의")
 class ModifyPersonalInfoServiceTest {
 
     @Mock
-    private OneseoService oneseoService;
-    @Mock
-    private OneseoPrivacyDetailRepository oneseoPrivacyDetailRepository;
+    private MemberService memberService;
 
     @InjectMocks
     private ModifyPersonalInfoService modifyPersonalInfoService;
@@ -48,184 +39,47 @@ class ModifyPersonalInfoServiceTest {
 
         private final Long memberId = 1L;
 
-        private ModifyPersonalInfoReqDto buildReqDto(GraduationType graduationType,
-                String schoolTeacherName,
-                String schoolTeacherPhoneNumber,
-                String schoolName,
-                String schoolAddress) {
-            return ModifyPersonalInfoReqDto.builder().name("홍길동").birth(LocalDate.of(2009, 1, 1)).sex(Sex.MALE)
-                    .guardianName("김보호").guardianPhoneNumber("01000000001").relationshipWithGuardian("모")
-                    .profileImg("https://abc.com/img.jpg").address("광주광역시 광산구 송정동 상무대로 312").detailAddress("101동 1001호")
-                    .graduationType(graduationType).schoolTeacherName(schoolTeacherName)
-                    .schoolTeacherPhoneNumber(schoolTeacherPhoneNumber).schoolName(schoolName)
-                    .schoolAddress(schoolAddress).graduationDate("2025-02").studentNumber("30508").build();
+        private ModifyPersonalInfoReqDto buildReqDto(String name, LocalDate birth, Sex sex) {
+            return ModifyPersonalInfoReqDto.builder().name(name).birth(birth).sex(sex).build();
         }
 
         @Nested
-        @DisplayName("졸업예정(CANDIDATE)이고 중학교 정보가 모두 입력된 경우")
-        class Context_with_candidate_and_full_school_info {
+        @DisplayName("유효한 회원 ID와 인적사항 데이터가 주어진 경우")
+        class Context_with_valid_member_id_and_data {
 
-            private Oneseo oneseo;
             private Member member;
 
             @BeforeEach
             void setUp() {
                 member = mock(Member.class);
-                oneseo = Oneseo.builder().id(1L).member(member)
-                        .entranceTestResult(EntranceTestResult.builder().firstTestPassYn(null).build()).build();
-
-                given(oneseoService.findWithMemberByMemberIdOrThrow(memberId)).willReturn(oneseo);
+                given(memberService.findByIdForUpdateOrThrow(memberId)).willReturn(member);
             }
 
             @Test
-            @DisplayName("OneseoPrivacyDetail을 저장하고 회원 정보를 수정한다")
-            void it_saves_privacy_detail_and_modifies_member() {
-                ModifyPersonalInfoReqDto reqDto = buildReqDto(CANDIDATE,
-                        "김선생",
-                        "01000000002",
-                        "금호중앙중학교",
-                        "광주광역시 북구 운암2동");
+            @DisplayName("회원의 이름, 생년월일, 성별을 수정한다")
+            void it_modifies_member_personal_info() {
+                ModifyPersonalInfoReqDto reqDto = buildReqDto("홍길동", LocalDate.of(2009, 1, 1), Sex.MALE);
 
                 modifyPersonalInfoService.execute(reqDto, memberId);
-
-                ArgumentCaptor<OneseoPrivacyDetail> captor = ArgumentCaptor.forClass(OneseoPrivacyDetail.class);
-                verify(oneseoPrivacyDetailRepository).save(captor.capture());
-
-                OneseoPrivacyDetail saved = captor.getValue();
-                assertEquals(oneseo.getId(), saved.getId());
-                assertEquals(oneseo, saved.getOneseo());
-                assertEquals(CANDIDATE, saved.getGraduationType());
-                assertEquals("2025-02", saved.getGraduationDate());
-                assertEquals("광주광역시 광산구 송정동 상무대로 312", saved.getAddress());
-                assertEquals("101동 1001호", saved.getDetailAddress());
-                assertEquals("https://abc.com/img.jpg", saved.getProfileImg());
-                assertEquals("김보호", saved.getGuardianName());
-                assertEquals("01000000001", saved.getGuardianPhoneNumber());
-                assertEquals("모", saved.getRelationshipWithGuardian());
-                assertEquals("김선생", saved.getSchoolTeacherName());
-                assertEquals("01000000002", saved.getSchoolTeacherPhoneNumber());
-                assertEquals("금호중앙중학교", saved.getSchoolName());
-                assertEquals("광주광역시 북구 운암2동", saved.getSchoolAddress());
-                assertEquals("30508", saved.getStudentNumber());
 
                 verify(member).modifyMember("홍길동", LocalDate.of(2009, 1, 1), member.getPhoneNumber(), Sex.MALE);
             }
         }
 
         @Nested
-        @DisplayName("졸업(GRADUATE) 타입이고 중학교 정보가 없는 경우")
-        class Context_with_graduate_and_no_school_info {
-
-            @BeforeEach
-            void setUp() {
-                Member member = mock(Member.class);
-                Oneseo oneseo = Oneseo.builder().id(1L).member(member)
-                        .entranceTestResult(EntranceTestResult.builder().firstTestPassYn(null).build()).build();
-
-                given(oneseoService.findWithMemberByMemberIdOrThrow(memberId)).willReturn(oneseo);
-            }
-
-            @Test
-            @DisplayName("중학교 정보 검증 없이 OneseoPrivacyDetail을 저장한다")
-            void it_saves_privacy_detail_without_school_info_validation() {
-                ModifyPersonalInfoReqDto reqDto = buildReqDto(GRADUATE, null, null, null, null);
-
-                modifyPersonalInfoService.execute(reqDto, memberId);
-
-                verify(oneseoPrivacyDetailRepository).save(any(OneseoPrivacyDetail.class));
-            }
-        }
-
-        @Nested
-        @DisplayName("졸업예정(CANDIDATE)이지만 중학교 정보가 누락된 경우")
-        class Context_with_candidate_and_missing_school_info {
-
-            @BeforeEach
-            void setUp() {
-                Member member = mock(Member.class);
-                Oneseo oneseo = Oneseo.builder().id(1L).member(member)
-                        .entranceTestResult(EntranceTestResult.builder().firstTestPassYn(null).build()).build();
-
-                given(oneseoService.findWithMemberByMemberIdOrThrow(memberId)).willReturn(oneseo);
-            }
-
-            @Test
-            @DisplayName("schoolTeacherName이 없으면 ExpectedException을 던진다")
-            void it_throws_when_school_teacher_name_is_blank() {
-                ModifyPersonalInfoReqDto reqDto = buildReqDto(CANDIDATE,
-                        null,
-                        "01000000002",
-                        "금호중앙중학교",
-                        "광주광역시 북구 운암2동");
-
-                ExpectedException exception = assertThrows(ExpectedException.class,
-                        () -> modifyPersonalInfoService.execute(reqDto, memberId));
-
-                assertEquals("중학교 졸업예정인 지원자는 현재 재학 중인 중학교 정보를 필수로 입력해야 합니다.", exception.getMessage());
-                assertEquals(HttpStatus.BAD_REQUEST, exception.getStatusCode());
-            }
-
-            @Test
-            @DisplayName("schoolName이 없으면 ExpectedException을 던진다")
-            void it_throws_when_school_name_is_blank() {
-                ModifyPersonalInfoReqDto reqDto = buildReqDto(CANDIDATE, "김선생", "01000000002", null, "광주광역시 북구 운암2동");
-
-                ExpectedException exception = assertThrows(ExpectedException.class,
-                        () -> modifyPersonalInfoService.execute(reqDto, memberId));
-
-                assertEquals("중학교 졸업예정인 지원자는 현재 재학 중인 중학교 정보를 필수로 입력해야 합니다.", exception.getMessage());
-                assertEquals(HttpStatus.BAD_REQUEST, exception.getStatusCode());
-            }
-        }
-
-        @Nested
-        @DisplayName("1차 전형 결과가 이미 산출된 경우")
-        class Context_when_first_test_result_already_announced {
-
-            @BeforeEach
-            void setUp() {
-                Member member = mock(Member.class);
-                Oneseo oneseo = Oneseo.builder().id(1L).member(member)
-                        .entranceTestResult(EntranceTestResult.builder().firstTestPassYn(YES).build()).build();
-
-                given(oneseoService.findWithMemberByMemberIdOrThrow(memberId)).willReturn(oneseo);
-            }
-
-            @Test
-            @DisplayName("ExpectedException을 던진다")
-            void it_throws_expected_exception() {
-                ModifyPersonalInfoReqDto reqDto = buildReqDto(CANDIDATE,
-                        "김선생",
-                        "01000000002",
-                        "금호중앙중학교",
-                        "광주광역시 북구 운암2동");
-
-                ExpectedException exception = assertThrows(ExpectedException.class,
-                        () -> modifyPersonalInfoService.execute(reqDto, memberId));
-
-                assertEquals("1차 전형 결과 산출 이후에는 작업을 진행할 수 없습니다.", exception.getMessage());
-                assertEquals(HttpStatus.FORBIDDEN, exception.getStatusCode());
-            }
-        }
-
-        @Nested
-        @DisplayName("회원 ID가 유효하지 않은 경우")
-        class Context_with_invalid_member_id {
+        @DisplayName("존재하지 않는 회원 ID가 주어진 경우")
+        class Context_with_nonexistent_member_id {
 
             @BeforeEach
             void setUp() {
                 doThrow(new ExpectedException("존재하지 않는 지원자입니다. member ID: " + memberId, HttpStatus.NOT_FOUND))
-                        .when(oneseoService).findWithMemberByMemberIdOrThrow(memberId);
+                        .when(memberService).findByIdForUpdateOrThrow(memberId);
             }
 
             @Test
             @DisplayName("ExpectedException을 던진다")
             void it_throws_expected_exception() {
-                ModifyPersonalInfoReqDto reqDto = buildReqDto(CANDIDATE,
-                        "김선생",
-                        "01000000002",
-                        "금호중앙중학교",
-                        "광주광역시 북구 운암2동");
+                ModifyPersonalInfoReqDto reqDto = buildReqDto("홍길동", LocalDate.of(2009, 1, 1), Sex.MALE);
 
                 ExpectedException exception = assertThrows(ExpectedException.class,
                         () -> modifyPersonalInfoService.execute(reqDto, memberId));


### PR DESCRIPTION
## 개요

인적사항 수정 API의 동작 방식을 변경합니다. 기존에는 원서(`OneseoPrivacyDetail`)에 인적사항을 저장하는 구조였으나, 이를 `Member` 엔티티를 직접 수정하는 구조로 변경하였습니다. 또한 사용자 본인 수정과 어드민 수정 두 가지 엔드포인트를 제공합니다.

## 본문

### 변경

- `ModifyPersonalInfoReqDto`: 기존 원서 관련 필드(보호자 정보, 학교 정보, 주소 등) 제거 → `name`, `birth`, `sex` 3개 필드만 유지
- `ModifyPersonalInfoService`: `OneseoPrivacyDetail` 저장 로직 제거, `MemberService`를 통해 `Member` 엔티티의 이름/생년월일/성별을 직접 수정하도록 변경
- `OneseoController`
  - `PATCH /oneseo/v3/personal-info/me` — 사용자가 자신의 인적사항 수정 (`@AuthRequest`)
  - `PATCH /oneseo/v3/personal-info/{memberId}` — 어드민이 특정 회원의 인적사항 수정 (`@PathVariable`)
- `ModifyPersonalInfoServiceTest`: 변경된 서비스 로직에 맞게 테스트 재작성

---

# RCA 룰

r: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)  
c: 웬만하면 반영해 주세요. (Comment)  
a: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)