### PR TITLE
[oneseo] 원서 없이도 인적사항 수정 가능하도록 수정

### DIFF
--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyPersonalInfoService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyPersonalInfoService.java
@@ -6,25 +6,30 @@ import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
 import team.themoment.hellogsmv3.domain.member.entity.Member;
+import team.themoment.hellogsmv3.domain.member.service.MemberService;
 import team.themoment.hellogsmv3.domain.oneseo.dto.request.ModifyPersonalInfoReqDto;
 import team.themoment.hellogsmv3.domain.oneseo.entity.Oneseo;
+import team.themoment.hellogsmv3.domain.oneseo.repository.OneseoRepository;
+
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
 public class ModifyPersonalInfoService {
 
-    private final OneseoService oneseoService;
+    private final MemberService memberService;
+    private final OneseoRepository oneseoRepository;
 
     @Transactional
     @CacheEvict(value = OneseoService.ONESEO_CACHE_VALUE, key = "#memberId")
     public void execute(ModifyPersonalInfoReqDto reqDto, Long memberId, boolean checkFirstTest) {
-        Oneseo oneseo = oneseoService.findWithMemberByMemberIdOrThrow(memberId);
+        Member member = memberService.findByIdOrThrow(memberId);
 
         if (checkFirstTest) {
-            OneseoService.isBeforeFirstTest(oneseo.getEntranceTestResult().getFirstTestPassYn());
+            Optional<Oneseo> oneseo = oneseoRepository.findByMember(member);
+            oneseo.ifPresent(o -> OneseoService.isBeforeFirstTest(o.getEntranceTestResult().getFirstTestPassYn()));
         }
 
-        Member member = oneseo.getMember();
         member.modifyMember(reqDto.name(), reqDto.birth(), member.getPhoneNumber(), reqDto.sex());
     }
 }

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyPersonalInfoService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyPersonalInfoService.java
@@ -27,7 +27,7 @@ public class ModifyPersonalInfoService {
 
         if (checkFirstTest) {
             Optional<Oneseo> oneseo = oneseoRepository.findByMember(member);
-            oneseo.ifPresent(o -> OneseoService.isBeforeFirstTest(o.getEntranceTestResult().getFirstTestPassYn()));
+            oneseo.map(Oneseo::getEntranceTestResult).ifPresent(result -> OneseoService.isBeforeFirstTest(result.getFirstTestPassYn()));
         }
 
         member.modifyMember(reqDto.name(), reqDto.birth(), member.getPhoneNumber(), reqDto.sex());

--- a/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyPersonalInfoServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyPersonalInfoServiceTest.java
@@ -5,6 +5,7 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.*;
 
 import java.time.LocalDate;
+import java.util.Optional;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -15,17 +16,22 @@ import org.springframework.http.HttpStatus;
 
 import team.themoment.hellogsmv3.domain.member.entity.Member;
 import team.themoment.hellogsmv3.domain.member.entity.type.Sex;
+import team.themoment.hellogsmv3.domain.member.service.MemberService;
 import team.themoment.hellogsmv3.domain.oneseo.dto.request.ModifyPersonalInfoReqDto;
 import team.themoment.hellogsmv3.domain.oneseo.entity.EntranceTestResult;
 import team.themoment.hellogsmv3.domain.oneseo.entity.Oneseo;
 import team.themoment.hellogsmv3.domain.oneseo.entity.type.YesNo;
+import team.themoment.hellogsmv3.domain.oneseo.repository.OneseoRepository;
 import team.themoment.sdk.exception.ExpectedException;
 
 @DisplayName("ModifyPersonalInfoService 클래스의")
 class ModifyPersonalInfoServiceTest {
 
     @Mock
-    private OneseoService oneseoService;
+    private MemberService memberService;
+
+    @Mock
+    private OneseoRepository oneseoRepository;
 
     @InjectMocks
     private ModifyPersonalInfoService modifyPersonalInfoService;
@@ -50,16 +56,15 @@ class ModifyPersonalInfoServiceTest {
         class Context_with_first_test_not_announced {
 
             private Member member;
-            private Oneseo oneseo;
 
             @BeforeEach
             void setUp() {
                 member = mock(Member.class);
-                oneseo = mock(Oneseo.class);
+                Oneseo oneseo = mock(Oneseo.class);
                 EntranceTestResult entranceTestResult = mock(EntranceTestResult.class);
 
-                given(oneseoService.findWithMemberByMemberIdOrThrow(memberId)).willReturn(oneseo);
-                given(oneseo.getMember()).willReturn(member);
+                given(memberService.findByIdOrThrow(memberId)).willReturn(member);
+                given(oneseoRepository.findByMember(member)).willReturn(Optional.of(oneseo));
                 given(oneseo.getEntranceTestResult()).willReturn(entranceTestResult);
                 given(entranceTestResult.getFirstTestPassYn()).willReturn(null);
             }
@@ -79,12 +84,16 @@ class ModifyPersonalInfoServiceTest {
         @DisplayName("1차 전형 결과가 산출된 후 일반 사용자가 수정을 시도하는 경우")
         class Context_with_first_test_announced {
 
+            private Member member;
+
             @BeforeEach
             void setUp() {
+                member = mock(Member.class);
                 Oneseo oneseo = mock(Oneseo.class);
                 EntranceTestResult entranceTestResult = mock(EntranceTestResult.class);
 
-                given(oneseoService.findWithMemberByMemberIdOrThrow(memberId)).willReturn(oneseo);
+                given(memberService.findByIdOrThrow(memberId)).willReturn(member);
+                given(oneseoRepository.findByMember(member)).willReturn(Optional.of(oneseo));
                 given(oneseo.getEntranceTestResult()).willReturn(entranceTestResult);
                 given(entranceTestResult.getFirstTestPassYn()).willReturn(YesNo.YES);
             }
@@ -102,6 +111,31 @@ class ModifyPersonalInfoServiceTest {
         }
 
         @Nested
+        @DisplayName("원서가 없는 회원이 인적사항을 수정하는 경우")
+        class Context_with_no_oneseo {
+
+            private Member member;
+
+            @BeforeEach
+            void setUp() {
+                member = mock(Member.class);
+
+                given(memberService.findByIdOrThrow(memberId)).willReturn(member);
+                given(oneseoRepository.findByMember(member)).willReturn(Optional.empty());
+            }
+
+            @Test
+            @DisplayName("검증 없이 회원 정보를 수정한다")
+            void it_modifies_member_personal_info_without_oneseo() {
+                ModifyPersonalInfoReqDto reqDto = buildReqDto("홍길동", LocalDate.of(2009, 1, 1), Sex.MALE);
+
+                modifyPersonalInfoService.execute(reqDto, memberId, true);
+
+                verify(member).modifyMember("홍길동", LocalDate.of(2009, 1, 1), member.getPhoneNumber(), Sex.MALE);
+            }
+        }
+
+        @Nested
         @DisplayName("관리자가 1차 전형 결과 산출 이후 수정을 시도하는 경우")
         class Context_with_admin_after_first_test {
 
@@ -110,10 +144,8 @@ class ModifyPersonalInfoServiceTest {
             @BeforeEach
             void setUp() {
                 member = mock(Member.class);
-                Oneseo oneseo = mock(Oneseo.class);
 
-                given(oneseoService.findWithMemberByMemberIdOrThrow(memberId)).willReturn(oneseo);
-                given(oneseo.getMember()).willReturn(member);
+                given(memberService.findByIdOrThrow(memberId)).willReturn(member);
             }
 
             @Test
@@ -124,6 +156,7 @@ class ModifyPersonalInfoServiceTest {
                 modifyPersonalInfoService.execute(reqDto, memberId, false);
 
                 verify(member).modifyMember("홍길동", LocalDate.of(2009, 1, 1), member.getPhoneNumber(), Sex.MALE);
+                verify(oneseoRepository, never()).findByMember(any());
             }
         }
 
@@ -133,7 +166,7 @@ class ModifyPersonalInfoServiceTest {
 
             @BeforeEach
             void setUp() {
-                given(oneseoService.findWithMemberByMemberIdOrThrow(memberId)).willThrow(
+                given(memberService.findByIdOrThrow(memberId)).willThrow(
                         new ExpectedException("존재하지 않는 지원자입니다. member ID: " + memberId, HttpStatus.NOT_FOUND));
             }
 


### PR DESCRIPTION
## 개요

인적사항 수정 API가 원서(Oneseo) 존재 여부에 의존하고 있어, 원서가 없는 회원은 인적사항을 수정할 수 없는 문제를 수정합니다.

## 본문

인적사항 수정은 Member 엔티티에 대한 작업이므로 원서의 존재 여부와 무관하게 동작해야 합니다. 기존 구현은 `OneseoService`를 통해 원서를 먼저 조회한 뒤 Member를 가져오는 방식이었으나, 이를 `MemberService`로 Member를 직접 조회하도록 변경했습니다.

### 변경

- `ModifyPersonalInfoService`: `OneseoService` 의존성을 제거하고 `MemberService` + `OneseoRepository`로 교체
  - Member를 직접 조회하여 원서 없이도 인적사항 수정 가능
  - `checkFirstTest=true`인 경우 원서가 존재할 때만 1차 전형 결과 검증 수행, 원서가 없으면 검증 생략
- `ModifyPersonalInfoServiceTest`: 변경된 의존성에 맞게 Mock 교체 및 원서 없는 케이스 테스트 추가

---

# RCA 룰

r: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)  
c: 웬만하면 반영해 주세요. (Comment)  
a: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)