### PR TITLE
[oneseo] 임시 저장 시 수정 권한 승인 상태여도 허용하도록 수정

### DIFF
--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyPersonalInfoService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyPersonalInfoService.java
@@ -1,5 +1,7 @@
 package team.themoment.hellogsmv3.domain.oneseo.service;
 
+import java.util.Optional;
+
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -10,8 +12,6 @@ import team.themoment.hellogsmv3.domain.member.service.MemberService;
 import team.themoment.hellogsmv3.domain.oneseo.dto.request.ModifyPersonalInfoReqDto;
 import team.themoment.hellogsmv3.domain.oneseo.entity.Oneseo;
 import team.themoment.hellogsmv3.domain.oneseo.repository.OneseoRepository;
-
-import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -27,7 +27,8 @@ public class ModifyPersonalInfoService {
 
         if (checkFirstTest) {
             Optional<Oneseo> oneseo = oneseoRepository.findByMember(member);
-            oneseo.map(Oneseo::getEntranceTestResult).ifPresent(result -> OneseoService.isBeforeFirstTest(result.getFirstTestPassYn()));
+            oneseo.map(Oneseo::getEntranceTestResult)
+                    .ifPresent(result -> OneseoService.isBeforeFirstTest(result.getFirstTestPassYn()));
         }
 
         member.modifyMember(reqDto.name(), reqDto.birth(), member.getPhoneNumber(), reqDto.sex());

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/OneseoTempStorageService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/OneseoTempStorageService.java
@@ -20,6 +20,7 @@ import team.themoment.hellogsmv3.domain.oneseo.dto.response.DesiredMajorsResDto;
 import team.themoment.hellogsmv3.domain.oneseo.dto.response.FoundOneseoResDto;
 import team.themoment.hellogsmv3.domain.oneseo.dto.response.MiddleSchoolAchievementResDto;
 import team.themoment.hellogsmv3.domain.oneseo.dto.response.OneseoPrivacyDetailResDto;
+import team.themoment.hellogsmv3.domain.oneseo.entity.type.OneseoEditStatus;
 import team.themoment.hellogsmv3.domain.oneseo.repository.OneseoRepository;
 import team.themoment.hellogsmv3.global.thirdParty.feign.client.dto.request.LambdaScoreCalculatorReqDto;
 import team.themoment.hellogsmv3.global.thirdParty.feign.client.lambda.LambdaScoreCalculatorClient;
@@ -52,8 +53,11 @@ public class OneseoTempStorageService {
     }
 
     private void isNotExistOneseo(Member member) {
-        if (oneseoRepository.existsByMember(member))
-            throw new ExpectedException("이미 원서 제출을 하였습니다.", HttpStatus.BAD_REQUEST);
+        oneseoRepository.findByMember(member).ifPresent(oneseo -> {
+            if (oneseo.getOneseoEditStatus() != OneseoEditStatus.APPROVED) {
+                throw new ExpectedException("이미 원서 제출을 하였습니다.", HttpStatus.BAD_REQUEST);
+            }
+        });
     }
 
     private OneseoPrivacyDetailResDto buildOneseoPrivacyDetailResDto(Member member, OneseoTempReqDto reqDto) {

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/OneseoTempStorageService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/OneseoTempStorageService.java
@@ -39,7 +39,7 @@ public class OneseoTempStorageService {
     public FoundOneseoResDto execute(OneseoTempReqDto reqDto, Integer step, Long memberId) {
         Member member = memberService.findByIdOrThrow(memberId);
 
-        isNotExistOneseo(member);
+        validateOneseoEditable(member);
 
         OneseoPrivacyDetailResDto oneseoPrivacyDetailResDto = buildOneseoPrivacyDetailResDto(member, reqDto);
         MiddleSchoolAchievementResDto middleSchoolAchievementResDto = buildMiddleSchoolAchievementResDto(reqDto);
@@ -52,7 +52,7 @@ public class OneseoTempStorageService {
                 calculatedScoreResDto);
     }
 
-    private void isNotExistOneseo(Member member) {
+    private void validateOneseoEditable(Member member) {
         oneseoRepository.findByMember(member).ifPresent(oneseo -> {
             if (oneseo.getOneseoEditStatus() != OneseoEditStatus.APPROVED) {
                 throw new ExpectedException("이미 원서 제출을 하였습니다.", HttpStatus.BAD_REQUEST);

--- a/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/OneseoTempStorageServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/OneseoTempStorageServiceTest.java
@@ -7,6 +7,7 @@ import static org.mockito.BDDMockito.given;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -24,8 +25,10 @@ import team.themoment.hellogsmv3.domain.oneseo.dto.request.MiddleSchoolAchieveme
 import team.themoment.hellogsmv3.domain.oneseo.dto.request.OneseoTempReqDto;
 import team.themoment.hellogsmv3.domain.oneseo.dto.response.CalculatedScoreResDto;
 import team.themoment.hellogsmv3.domain.oneseo.dto.response.FoundOneseoResDto;
+import team.themoment.hellogsmv3.domain.oneseo.entity.Oneseo;
 import team.themoment.hellogsmv3.domain.oneseo.entity.type.GraduationType;
 import team.themoment.hellogsmv3.domain.oneseo.entity.type.Major;
+import team.themoment.hellogsmv3.domain.oneseo.entity.type.OneseoEditStatus;
 import team.themoment.hellogsmv3.domain.oneseo.repository.OneseoRepository;
 import team.themoment.hellogsmv3.global.thirdParty.feign.client.dto.request.LambdaScoreCalculatorReqDto;
 import team.themoment.hellogsmv3.global.thirdParty.feign.client.lambda.LambdaScoreCalculatorClient;
@@ -96,7 +99,7 @@ public class OneseoTempStorageServiceTest {
 
                 @BeforeEach
                 void setUp() {
-                    given(oneseoRepository.existsByMember(member)).willReturn(false);
+                    given(oneseoRepository.findByMember(member)).willReturn(Optional.empty());
                     given(lambdaScoreCalculatorClient.calculateScore(any(LambdaScoreCalculatorReqDto.class)))
                             .willReturn(calculatedScoreResDto);
                 }
@@ -166,11 +169,12 @@ public class OneseoTempStorageServiceTest {
             }
 
             @Nested
-            @DisplayName("회원이 원서를 제출했다면")
-            class Oneseo_exist {
+            @DisplayName("회원이 원서를 제출했고 수정 권한이 없다면")
+            class Oneseo_exist_without_edit_permission {
                 @BeforeEach
                 void setUp() {
-                    given(oneseoRepository.existsByMember(member)).willReturn(true);
+                    Oneseo oneseo = Oneseo.builder().member(member).oneseoEditStatus(OneseoEditStatus.NONE).build();
+                    given(oneseoRepository.findByMember(member)).willReturn(Optional.of(oneseo));
                 }
 
                 @Test
@@ -181,6 +185,30 @@ public class OneseoTempStorageServiceTest {
 
                     assertEquals("이미 원서 제출을 하였습니다.", exception.getMessage());
                     assertEquals(HttpStatus.BAD_REQUEST, exception.getStatusCode());
+                }
+            }
+
+            @Nested
+            @DisplayName("회원이 원서를 제출했고 수정 권한이 APPROVED라면")
+            class Oneseo_exist_with_approved_edit_permission {
+                private final CalculatedScoreResDto calculatedScoreResDto = CalculatedScoreResDto.builder()
+                        .generalSubjectsScore(new BigDecimal("80.000"))
+                        .artsPhysicalSubjectsScore(new BigDecimal("10.000")).attendanceScore(new BigDecimal("5.000"))
+                        .volunteerScore(new BigDecimal("5.000")).totalScore(new BigDecimal("100.000")).build();
+
+                @BeforeEach
+                void setUp() {
+                    Oneseo oneseo = Oneseo.builder().member(member).oneseoEditStatus(OneseoEditStatus.APPROVED).build();
+                    given(oneseoRepository.findByMember(member)).willReturn(Optional.of(oneseo));
+                    given(lambdaScoreCalculatorClient.calculateScore(any(LambdaScoreCalculatorReqDto.class)))
+                            .willReturn(calculatedScoreResDto);
+                }
+
+                @Test
+                @DisplayName("FoundOneseoResDto를 반환한다.")
+                void it_returns_found_oneseo_res_dto() {
+                    FoundOneseoResDto result = oneseoTempStorageService.execute(reqDto, step, memberId);
+                    assertNotNull(result);
                 }
             }
         }

--- a/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/OneseoTempStorageServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/OneseoTempStorageServiceTest.java
@@ -209,6 +209,13 @@ public class OneseoTempStorageServiceTest {
                 void it_returns_found_oneseo_res_dto() {
                     FoundOneseoResDto result = oneseoTempStorageService.execute(reqDto, step, memberId);
                     assertNotNull(result);
+                    assertNull(result.oneseoId());
+                    assertNull(result.submitCode());
+                    assertEquals(reqDto.screening(), result.wantedScreening());
+                    assertEquals(reqDto.firstDesiredMajor(), result.desiredMajors().firstDesiredMajor());
+                    assertEquals(reqDto.graduationType(), result.privacyDetail().graduationType());
+                    assertEquals(calculatedScoreResDto, result.calculatedScore());
+                    assertEquals(step, result.step());
                 }
             }
         }


### PR DESCRIPTION
## 개요

원서 최종 제출 후 수정 권한(APPROVED)을 받은 경우에도 임시 저장이 가능하도록 변경했습니다.

## 본문

기존 `OneseoTempStorageService`는 원서가 존재하면 무조건 예외를 던졌으나, 수정 권한 승인(`OneseoEditStatus.APPROVED`) 상태일 때는 임시 저장을 허용해야 하는 요구사항이 생겼습니다.
#362 

### 변경

- `OneseoTempStorageService.isNotExistOneseo`: `existsByMember` → `findByMember`로 변경하여 원서 엔티티를 조회한 뒤, `oneseoEditStatus`가 `APPROVED`가 아닐 때만 예외를 발생시키도록 수정
- `OneseoTempStorageServiceTest`: 기존 원서 존재 시 예외 케이스를 `NONE` 상태 기준으로 명확히 수정하고, `APPROVED` 상태에서 정상 반환하는 테스트 케이스 추가