### PR TITLE
[oneseo] 원서 검색 수정 상태 필터를 Boolean requested에서 OneseoEditStatusTag status로 변경

### DIFF
--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/controller/OneseoController.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/controller/OneseoController.java
@@ -100,7 +100,7 @@ public class OneseoController {
             @RequestParam(required = false) ScreeningCategory screeningTag,
             @Schema(description = "서류 제출 여부") @RequestParam(required = false) YesNo isSubmitted,
             @RequestParam(name = "keyword", required = false) String keyword,
-            @Schema(description = "수정 상태 필터 (ALL, PENDING, APPROVED)") @RequestParam(required = false) OneseoEditStatusTag status) {
+            @Schema(description = "수정 상태 필터 (ANY_EDIT, REQUESTED, APPROVED)") @RequestParam(required = false) OneseoEditStatusTag status) {
         return searchOneseoService.execute(page, size, testResultTag, screeningTag, isSubmitted, keyword, status);
     }
 

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/controller/OneseoController.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/controller/OneseoController.java
@@ -100,8 +100,8 @@ public class OneseoController {
             @RequestParam(required = false) ScreeningCategory screeningTag,
             @Schema(description = "서류 제출 여부") @RequestParam(required = false) YesNo isSubmitted,
             @RequestParam(name = "keyword", required = false) String keyword,
-            @Schema(description = "수정 요청/승인 원서 필터") @RequestParam(required = false) Boolean requested) {
-        return searchOneseoService.execute(page, size, testResultTag, screeningTag, isSubmitted, keyword, requested);
+            @Schema(description = "수정 상태 필터 (ALL, PENDING, APPROVED)") @RequestParam(required = false) OneseoEditStatusTag status) {
+        return searchOneseoService.execute(page, size, testResultTag, screeningTag, isSubmitted, keyword, status);
     }
 
     @Operation(summary = "내 원서 조회", description = "내 원서 정보를 조회합니다. 임시 저장된 원서가 있다면 임시 저장된 원서를 조회합니다.")

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/dto/request/OneseoEditStatusTag.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/dto/request/OneseoEditStatusTag.java
@@ -1,0 +1,5 @@
+package team.themoment.hellogsmv3.domain.oneseo.dto.request;
+
+public enum OneseoEditStatusTag {
+    ALL, PENDING, APPROVED
+}

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/dto/request/OneseoEditStatusTag.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/dto/request/OneseoEditStatusTag.java
@@ -1,5 +1,5 @@
 package team.themoment.hellogsmv3.domain.oneseo.dto.request;
 
 public enum OneseoEditStatusTag {
-    ALL, PENDING, APPROVED
+    ANY_EDIT, REQUESTED, APPROVED
 }

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/repository/custom/CustomOneseoRepository.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/repository/custom/CustomOneseoRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 import team.themoment.hellogsmv3.domain.oneseo.dto.internal.FoundMemberAndOneseoDto;
+import team.themoment.hellogsmv3.domain.oneseo.dto.request.OneseoEditStatusTag;
 import team.themoment.hellogsmv3.domain.oneseo.dto.request.TestResultTag;
 import team.themoment.hellogsmv3.domain.oneseo.dto.response.AdmissionTicketsResDto;
 import team.themoment.hellogsmv3.domain.oneseo.dto.response.SearchOneseoResDto;
@@ -28,7 +29,7 @@ public interface CustomOneseoRepository {
             ScreeningCategory screening,
             YesNo isSubmitted,
             TestResultTag testResultTag,
-            Boolean requested,
+            OneseoEditStatusTag status,
             Pageable pageable);
 
     List<AdmissionTicketsResDto> findAdmissionTickets();

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/repository/custom/impl/CustomOneseoRepositoryImpl.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/repository/custom/impl/CustomOneseoRepositoryImpl.java
@@ -161,8 +161,9 @@ public class CustomOneseoRepositoryImpl implements CustomOneseoRepository {
             return;
 
         switch (status) {
-            case ALL -> builder.and(oneseo.oneseoEditStatus.in(OneseoEditStatus.REQUESTED, OneseoEditStatus.APPROVED));
-            case PENDING -> builder.and(oneseo.oneseoEditStatus.eq(OneseoEditStatus.REQUESTED));
+            case ANY_EDIT ->
+                builder.and(oneseo.oneseoEditStatus.in(OneseoEditStatus.REQUESTED, OneseoEditStatus.APPROVED));
+            case REQUESTED -> builder.and(oneseo.oneseoEditStatus.eq(OneseoEditStatus.REQUESTED));
             case APPROVED -> builder.and(oneseo.oneseoEditStatus.eq(OneseoEditStatus.APPROVED));
         }
     }

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/repository/custom/impl/CustomOneseoRepositoryImpl.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/repository/custom/impl/CustomOneseoRepositoryImpl.java
@@ -26,6 +26,7 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 
 import lombok.RequiredArgsConstructor;
 import team.themoment.hellogsmv3.domain.oneseo.dto.internal.FoundMemberAndOneseoDto;
+import team.themoment.hellogsmv3.domain.oneseo.dto.request.OneseoEditStatusTag;
 import team.themoment.hellogsmv3.domain.oneseo.dto.request.TestResultTag;
 import team.themoment.hellogsmv3.domain.oneseo.dto.response.AdmissionTicketsResDto;
 import team.themoment.hellogsmv3.domain.oneseo.dto.response.SearchOneseoResDto;
@@ -70,10 +71,10 @@ public class CustomOneseoRepositoryImpl implements CustomOneseoRepository {
             ScreeningCategory screeningTag,
             YesNo isSubmitted,
             TestResultTag testResultTag,
-            Boolean requested,
+            OneseoEditStatusTag status,
             Pageable pageable) {
 
-        BooleanBuilder builder = createBooleanBuilder(keyword, screeningTag, isSubmitted, testResultTag, requested);
+        BooleanBuilder builder = createBooleanBuilder(keyword, screeningTag, isSubmitted, testResultTag, status);
 
         List<SearchOneseoResDto> oneseos = queryFactory
                 .select(Projections.constructor(SearchOneseoResDto.class,
@@ -143,23 +144,27 @@ public class CustomOneseoRepositoryImpl implements CustomOneseoRepository {
             ScreeningCategory screeningTag,
             YesNo isSubmitted,
             TestResultTag testResultTag,
-            Boolean requested) {
+            OneseoEditStatusTag status) {
 
         BooleanBuilder builder = new BooleanBuilder();
         applyKeyword(builder, keyword);
         applyScreeningTag(builder, screeningTag);
         applyIsSubmittedTag(builder, isSubmitted);
         applyTestResultTag(builder, testResultTag);
-        applyRequestedTag(builder, requested);
+        applyEditStatusTag(builder, status);
 
         return builder;
     }
 
-    private void applyRequestedTag(BooleanBuilder builder, Boolean requested) {
-        if (requested == null || !requested)
+    private void applyEditStatusTag(BooleanBuilder builder, OneseoEditStatusTag status) {
+        if (status == null)
             return;
 
-        builder.and(oneseo.oneseoEditStatus.in(OneseoEditStatus.REQUESTED, OneseoEditStatus.APPROVED));
+        switch (status) {
+            case ALL -> builder.and(oneseo.oneseoEditStatus.in(OneseoEditStatus.REQUESTED, OneseoEditStatus.APPROVED));
+            case PENDING -> builder.and(oneseo.oneseoEditStatus.eq(OneseoEditStatus.REQUESTED));
+            case APPROVED -> builder.and(oneseo.oneseoEditStatus.eq(OneseoEditStatus.APPROVED));
+        }
     }
 
     private void applyKeyword(BooleanBuilder builder, String keyword) {

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/SearchOneseoService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/SearchOneseoService.java
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
+import team.themoment.hellogsmv3.domain.oneseo.dto.request.OneseoEditStatusTag;
 import team.themoment.hellogsmv3.domain.oneseo.dto.request.TestResultTag;
 import team.themoment.hellogsmv3.domain.oneseo.dto.response.SearchOneseoPageInfoDto;
 import team.themoment.hellogsmv3.domain.oneseo.dto.response.SearchOneseoResDto;
@@ -28,14 +29,14 @@ public class SearchOneseoService {
             ScreeningCategory screeningTag,
             YesNo isSubmitted,
             String keyword,
-            Boolean requested) {
+            OneseoEditStatusTag status) {
 
         Pageable pageable = PageRequest.of(page, size);
         Page<SearchOneseoResDto> oneseoPage = findOneseoByTagsAndKeyword(testResultTag,
                 screeningTag,
                 isSubmitted,
                 keyword,
-                requested,
+                status,
                 pageable);
 
         SearchOneseoPageInfoDto infoDto = SearchOneseoPageInfoDto.builder().totalPages(oneseoPage.getTotalPages())
@@ -48,13 +49,13 @@ public class SearchOneseoService {
             ScreeningCategory screeningTag,
             YesNo isSubmitted,
             String keyword,
-            Boolean requested,
+            OneseoEditStatusTag status,
             Pageable pageable) {
         return oneseoRepository.findAllByKeywordAndScreeningAndSubmissionStatusAndTestResult(keyword,
                 screeningTag,
                 isSubmitted,
                 testResultTag,
-                requested,
+                status,
                 pageable);
     }
 }

--- a/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/SearchOneseoServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/SearchOneseoServiceTest.java
@@ -22,6 +22,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 
 import team.themoment.hellogsmv3.domain.member.entity.Member;
+import team.themoment.hellogsmv3.domain.oneseo.dto.request.OneseoEditStatusTag;
 import team.themoment.hellogsmv3.domain.oneseo.dto.request.TestResultTag;
 import team.themoment.hellogsmv3.domain.oneseo.dto.response.SearchOneseoPageInfoDto;
 import team.themoment.hellogsmv3.domain.oneseo.dto.response.SearchOneseoResDto;
@@ -149,8 +150,8 @@ class SearchOneseoServiceTest {
         }
 
         @Nested
-        @DisplayName("requested=true가 주어진 경우")
-        class Context_with_requested_true {
+@DisplayName("status=ALL이 주어진 경우")
+        class Context_with_status_all {
 
             private Member member;
             private Oneseo oneseo;
@@ -175,15 +176,114 @@ class SearchOneseoServiceTest {
                         screeningTag,
                         isSubmitted,
                         testResultTag,
-                        true,
+                        OneseoEditStatusTag.ALL,
                         pageable)).willReturn(oneseoPage);
             }
 
             @Test
-            @DisplayName("수정 요청/승인 필터가 repository로 올바르게 전달된다")
-            void it_passes_requested_filter_to_repository() {
-                SearchOneseosResDto result = searchOneseoService
-                        .execute(page, size, testResultTag, screeningTag, isSubmitted, keyword, true);
+            @DisplayName("ALL 필터가 repository로 올바르게 전달된다")
+            void it_passes_all_status_filter_to_repository() {
+                SearchOneseosResDto result = searchOneseoService.execute(page,
+                        size,
+                        testResultTag,
+                        screeningTag,
+                        isSubmitted,
+                        keyword,
+                        OneseoEditStatusTag.ALL);
+
+                assertEquals(1, result.info().totalElements());
+                assertEquals(1, result.oneseos().size());
+            }
+        }
+
+        @Nested
+        @DisplayName("status=PENDING이 주어진 경우")
+        class Context_with_status_pending {
+
+            private Member member;
+            private Oneseo oneseo;
+            private OneseoPrivacyDetail oneseoPrivacyDetail;
+            private EntranceTestResult entranceTestResult;
+
+            @BeforeEach
+            void setUp() {
+                Pageable pageable = PageRequest.of(page, size);
+                member = buildMember();
+                oneseo = buildOneseo();
+                oneseoPrivacyDetail = buildOneseoPrivacyDetail();
+                entranceTestResult = buildEntranceTestResult();
+
+                SearchOneseoResDto searchOneseoResDto = buildSearchOneseoDto(member,
+                        oneseo,
+                        oneseoPrivacyDetail,
+                        entranceTestResult);
+                Page<SearchOneseoResDto> oneseoPage = new PageImpl<>(List.of(searchOneseoResDto), pageable, 1);
+
+                given(oneseoRepository.findAllByKeywordAndScreeningAndSubmissionStatusAndTestResult(keyword,
+                        screeningTag,
+                        isSubmitted,
+                        testResultTag,
+                        OneseoEditStatusTag.PENDING,
+                        pageable)).willReturn(oneseoPage);
+            }
+
+            @Test
+            @DisplayName("PENDING 필터가 repository로 올바르게 전달된다")
+            void it_passes_pending_status_filter_to_repository() {
+                SearchOneseosResDto result = searchOneseoService.execute(page,
+                        size,
+                        testResultTag,
+                        screeningTag,
+                        isSubmitted,
+                        keyword,
+                        OneseoEditStatusTag.PENDING);
+
+                assertEquals(1, result.info().totalElements());
+                assertEquals(1, result.oneseos().size());
+            }
+        }
+
+        @Nested
+        @DisplayName("status=APPROVED가 주어진 경우")
+        class Context_with_status_approved {
+
+            private Member member;
+            private Oneseo oneseo;
+            private OneseoPrivacyDetail oneseoPrivacyDetail;
+            private EntranceTestResult entranceTestResult;
+
+            @BeforeEach
+            void setUp() {
+                Pageable pageable = PageRequest.of(page, size);
+                member = buildMember();
+                oneseo = buildOneseo();
+                oneseoPrivacyDetail = buildOneseoPrivacyDetail();
+                entranceTestResult = buildEntranceTestResult();
+
+                SearchOneseoResDto searchOneseoResDto = buildSearchOneseoDto(member,
+                        oneseo,
+                        oneseoPrivacyDetail,
+                        entranceTestResult);
+                Page<SearchOneseoResDto> oneseoPage = new PageImpl<>(List.of(searchOneseoResDto), pageable, 1);
+
+                given(oneseoRepository.findAllByKeywordAndScreeningAndSubmissionStatusAndTestResult(keyword,
+                        screeningTag,
+                        isSubmitted,
+                        testResultTag,
+                        OneseoEditStatusTag.APPROVED,
+                        pageable)).willReturn(oneseoPage);
+            }
+
+            @Test
+            @DisplayName("APPROVED 필터가 repository로 올바르게 전달된다")
+            void it_passes_approved_status_filter_to_repository() {
+                SearchOneseosResDto result = searchOneseoService.execute(page,
+                        size,
+                        testResultTag,
+                        screeningTag,
+                        isSubmitted,
+                        keyword,
+                        OneseoEditStatusTag.APPROVED);
 
                 assertEquals(1, result.info().totalElements());
                 assertEquals(1, result.oneseos().size());

--- a/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/SearchOneseoServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/SearchOneseoServiceTest.java
@@ -150,8 +150,8 @@ class SearchOneseoServiceTest {
         }
 
         @Nested
-@DisplayName("status=ALL이 주어진 경우")
-        class Context_with_status_all {
+        @DisplayName("status=ANY_EDIT이 주어진 경우")
+        class Context_with_status_any_edit {
 
             private Member member;
             private Oneseo oneseo;
@@ -176,29 +176,31 @@ class SearchOneseoServiceTest {
                         screeningTag,
                         isSubmitted,
                         testResultTag,
-                        OneseoEditStatusTag.ALL,
+                        OneseoEditStatusTag.ANY_EDIT,
                         pageable)).willReturn(oneseoPage);
             }
 
             @Test
-            @DisplayName("ALL 필터가 repository로 올바르게 전달된다")
-            void it_passes_all_status_filter_to_repository() {
+            @DisplayName("ANY_EDIT 필터가 repository로 올바르게 전달된다")
+            void it_passes_any_edit_status_filter_to_repository() {
                 SearchOneseosResDto result = searchOneseoService.execute(page,
                         size,
                         testResultTag,
                         screeningTag,
                         isSubmitted,
                         keyword,
-                        OneseoEditStatusTag.ALL);
+                        OneseoEditStatusTag.ANY_EDIT);
 
                 assertEquals(1, result.info().totalElements());
                 assertEquals(1, result.oneseos().size());
+                assertEquals(member.getId(), result.oneseos().get(0).memberId());
+                assertEquals(oneseo.getOneseoSubmitCode(), result.oneseos().get(0).submitCode());
             }
         }
 
         @Nested
-        @DisplayName("status=PENDING이 주어진 경우")
-        class Context_with_status_pending {
+        @DisplayName("status=REQUESTED가 주어진 경우")
+        class Context_with_status_requested {
 
             private Member member;
             private Oneseo oneseo;
@@ -223,23 +225,25 @@ class SearchOneseoServiceTest {
                         screeningTag,
                         isSubmitted,
                         testResultTag,
-                        OneseoEditStatusTag.PENDING,
+                        OneseoEditStatusTag.REQUESTED,
                         pageable)).willReturn(oneseoPage);
             }
 
             @Test
-            @DisplayName("PENDING 필터가 repository로 올바르게 전달된다")
-            void it_passes_pending_status_filter_to_repository() {
+            @DisplayName("REQUESTED 필터가 repository로 올바르게 전달된다")
+            void it_passes_requested_status_filter_to_repository() {
                 SearchOneseosResDto result = searchOneseoService.execute(page,
                         size,
                         testResultTag,
                         screeningTag,
                         isSubmitted,
                         keyword,
-                        OneseoEditStatusTag.PENDING);
+                        OneseoEditStatusTag.REQUESTED);
 
                 assertEquals(1, result.info().totalElements());
                 assertEquals(1, result.oneseos().size());
+                assertEquals(member.getId(), result.oneseos().get(0).memberId());
+                assertEquals(oneseo.getOneseoSubmitCode(), result.oneseos().get(0).submitCode());
             }
         }
 
@@ -287,6 +291,8 @@ class SearchOneseoServiceTest {
 
                 assertEquals(1, result.info().totalElements());
                 assertEquals(1, result.oneseos().size());
+                assertEquals(member.getId(), result.oneseos().get(0).memberId());
+                assertEquals(oneseo.getOneseoSubmitCode(), result.oneseos().get(0).submitCode());
             }
         }
     }


### PR DESCRIPTION
## 개요

원서 검색 API의 `requested: Boolean` 파라미터를 `status: OneseoEditStatusTag`로 교체합니다. 기존에는 `true/false`만 구분 가능했으나, `ALL`, `PENDING`, `APPROVED` 세 가지 상태로 세분화하여 수정 권한 요청/승인 원서를 더 정확하게 필터링할 수 있습니다.

## 본문

기존 `requested=true`는 `oneseoEditStatus`가 `REQUESTED` 또는 `APPROVED`인 원서를 한 번에 조회하는 방식이었습니다. 이를 세 가지 값을 가지는 enum 파라미터로 교체하여 각 상태를 독립적으로 필터링할 수 있도록 변경했습니다.

- `status=ALL` → `REQUESTED` + `APPROVED` 모두 조회 (기존 `requested=true`와 동일)
- `status=PENDING` → `REQUESTED` 상태만 조회
- `status=APPROVED` → `APPROVED` 상태만 조회
- `status` 미전달 → 전체 조회 (기존 `requested=null`과 동일)

### 추가

- `OneseoEditStatusTag` enum (`ALL`, `PENDING`, `APPROVED`)

### 변경

- `GET /oneseo/v3/oneseo/search`: `requested: Boolean` 파라미터 제거, `status: OneseoEditStatusTag` 파라미터 추가
- `CustomOneseoRepository`, `CustomOneseoRepositoryImpl`, `SearchOneseoService`: 시그니처 변경
- `CustomOneseoRepositoryImpl.applyRequestedTag` → `applyEditStatusTag`로 교체 (switch 분기 처리)
- `SearchOneseoServiceTest`: `Context_with_requested_true` → `ALL` / `PENDING` / `APPROVED` 세 케이스로 분리