### PR TITLE
[oneseo] 성취점수 리스트 내 null 요소로 인한 NPE 수정

### DIFF
--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/OneseoService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/OneseoService.java
@@ -107,6 +107,8 @@ public class OneseoService {
             return null;
 
         achievements.forEach(achievement -> {
+            if (achievement == null)
+                throw new ExpectedException("예체능 성취점수에 null 값이 포함되어 있습니다.", HttpStatus.BAD_REQUEST);
             if (achievement != 0 && (achievement > 5 || achievement < 3))
                 throw new ExpectedException("올바르지 않은 예체능 등급이 입력되었습니다.", HttpStatus.BAD_REQUEST);
         });
@@ -119,6 +121,8 @@ public class OneseoService {
             return null;
 
         achievements.forEach(achievement -> {
+            if (achievement == null)
+                throw new ExpectedException("일반교과 성취점수에 null 값이 포함되어 있습니다.", HttpStatus.BAD_REQUEST);
             if (achievement > 5 || achievement < 0)
                 throw new ExpectedException("올바르지 않은 일반교과 등급이 입력되었습니다.", HttpStatus.BAD_REQUEST);
         });


### PR DESCRIPTION
## 개요

예체능 및 일반교과 성취점수 리스트에 `null` 요소가 포함된 요청이 들어올 때, `Integer` → `int` 언박싱 과정에서 `NullPointerException`이 발생해 500 에러를 반환하던 버그를 수정합니다.

## 본문

`validationArtsPhysicalAchievement`, `validationGeneralAchievement` 두 메서드에서 리스트 자체의 null 여부만 체크하고 개별 요소의 null 여부는 체크하지 않았습니다.

`achievements.forEach(achievement -> { if (achievement != 0 ...) })` 구문에서 `achievement`가 `null`이면 `int` 언박싱 시 NPE가 발생합니다.

### 변경

- `OneseoService.validationArtsPhysicalAchievement`: 리스트 요소 null 체크 추가 → `400 BAD_REQUEST` 반환
- `OneseoService.validationGeneralAchievement`: 리스트 요소 null 체크 추가 → `400 BAD_REQUEST` 반환

---

# RCA 룰

r: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)  
c: 웬만하면 반영해 주세요. (Comment)  
a: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)