### PR TITLE
[global] 테스트 코드 스타일 및 명칭 표준화

### DIFF
--- a/.agents/skills/commit/SKILL.md
+++ b/.agents/skills/commit/SKILL.md
@@ -34,12 +34,12 @@ git diff HEAD --stat
 
 ### Git Flow Branch Rules
 
-| Current branch | Action |
-|----------------|--------|
+| Current branch | Action                                                             |
+|----------------|--------------------------------------------------------------------|
 | `develop`      | Warn: direct commits to develop are unusual. Ask for confirmation. |
-| `main`         | STOP. Do not commit to main. Tell user to create a branch. |
-| `feature/*`    | Proceed normally |
-| `hotfix/*`     | Proceed normally |
+| `main`         | STOP. Do not commit to main. Tell user to create a branch.         |
+| `feature/*`    | Proceed normally                                                   |
+| `hotfix/*`     | Proceed normally                                                   |
 
 ## Step 3 — Analyze Changes
 

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -9,6 +9,7 @@
 Use the **Describe / Context / It** nested pattern:
 
 ```java
+@ExtendWith(MockitoExtension.class)
 @DisplayName("{Feature} {Subject} 테스트")
 class ActionFeatureServiceTest {
 
@@ -17,11 +18,6 @@ class ActionFeatureServiceTest {
 
     @InjectMocks
     private ActionFeatureService service;
-
-    @BeforeEach
-    void setUp() {
-        MockitoAnnotations.openMocks(this);
-    }
 
     @Nested
     @DisplayName("execute 메서드는")
@@ -66,6 +62,11 @@ class ActionFeatureServiceTest {
 | Nested Describe | `Describe_{methodName}`               |
 | Nested Context  | `Context_{condition}`                 |
 | Test method   | `it_{expected_behavior}()`               |
+
+## Mockito Initialization
+- Prefer `@ExtendWith(MockitoExtension.class)` for JUnit 5 unit tests
+- Do not call `MockitoAnnotations.openMocks(this)` in new tests
+- Keep a top-level `@BeforeEach` only when the test needs additional setup beyond mock initialization
 
 ## Stubbing Style — BDD (Preferred)
 ```java

--- a/.claude/skills/commit/SKILL.md
+++ b/.claude/skills/commit/SKILL.md
@@ -24,13 +24,13 @@ git diff HEAD --stat
 
 ### Git Flow Branch Rules
 
-| Current branch | Action |
-|----------------|--------|
+| Current branch | Action                                                                                                                                           |
+|----------------|--------------------------------------------------------------------------------------------------------------------------------------------------|
 | `develop`      | Warn the user that committing directly to `develop` is unusual. Suggest creating a feature branch first. Ask for confirmation before proceeding. |
-| `main`         | STOP. Do not commit to main. Tell the user to create a branch. |
-| `feature/*`    | Proceed normally |
-| `hotfix/*`     | Proceed normally |
-| Any other      | Proceed normally |
+| `main`         | STOP. Do not commit to main. Tell the user to create a branch.                                                                                   |
+| `feature/*`    | Proceed normally                                                                                                                                 |
+| `hotfix/*`     | Proceed normally                                                                                                                                 |
+| Any other      | Proceed normally                                                                                                                                 |
 
 If on `develop` and user confirms they want to commit directly, proceed.
 

--- a/src/test/java/team/themoment/hellogsmv3/domain/common/date/service/QueryDateServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/common/date/service/QueryDateServiceTest.java
@@ -9,13 +9,15 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import team.themoment.hellogsmv3.domain.common.date.dto.DateResDto;
 import team.themoment.hellogsmv3.global.security.data.ScheduleEnvironment;
 
+@ExtendWith(MockitoExtension.class)
 @DisplayName("QueryDateService 클래스의")
 class QueryDateServiceTest {
 
@@ -24,11 +26,6 @@ class QueryDateServiceTest {
 
     @InjectMocks
     private QueryDateService queryDateService;
-
-    @BeforeEach
-    void setUp() {
-        MockitoAnnotations.openMocks(this);
-    }
 
     @Nested
     @DisplayName("execute 메서드는")

--- a/src/test/java/team/themoment/hellogsmv3/domain/common/date/service/QueryDateServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/common/date/service/QueryDateServiceTest.java
@@ -1,0 +1,72 @@
+package team.themoment.hellogsmv3.domain.common.date.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.BDDMockito.given;
+
+import java.time.LocalDateTime;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import team.themoment.hellogsmv3.domain.common.date.dto.DateResDto;
+import team.themoment.hellogsmv3.global.security.data.ScheduleEnvironment;
+
+@DisplayName("QueryDateService 클래스의")
+class QueryDateServiceTest {
+
+    @Mock
+    private ScheduleEnvironment scheduleEnv;
+
+    @InjectMocks
+    private QueryDateService queryDateService;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Nested
+    @DisplayName("execute 메서드는")
+    class Describe_execute {
+
+        private final LocalDateTime submissionStart = LocalDateTime.of(2025, 1, 1, 9, 0);
+        private final LocalDateTime submissionEnd = LocalDateTime.of(2025, 1, 10, 18, 0);
+        private final LocalDateTime firstResults = LocalDateTime.of(2025, 2, 1, 9, 0);
+        private final LocalDateTime competency = LocalDateTime.of(2025, 2, 15, 9, 0);
+        private final LocalDateTime interview = LocalDateTime.of(2025, 3, 1, 9, 0);
+        private final LocalDateTime finalResults = LocalDateTime.of(2025, 3, 15, 9, 0);
+
+        @Nested
+        @DisplayName("ScheduleEnvironment가 정상적으로 주어지면")
+        class Context_with_valid_schedule_environment {
+
+            @BeforeEach
+            void setUp() {
+                given(scheduleEnv.oneseoSubmissionStart()).willReturn(submissionStart);
+                given(scheduleEnv.oneseoSubmissionEnd()).willReturn(submissionEnd);
+                given(scheduleEnv.firstResultsAnnouncement()).willReturn(firstResults);
+                given(scheduleEnv.competencyEvaluation()).willReturn(competency);
+                given(scheduleEnv.interview()).willReturn(interview);
+                given(scheduleEnv.finalResultsAnnouncement()).willReturn(finalResults);
+            }
+
+            @Test
+            @DisplayName("모든 일정 정보를 담은 DateResDto를 반환한다")
+            void it_returns_date_res_dto_with_all_schedule_info() {
+                DateResDto result = queryDateService.execute();
+
+                assertEquals(submissionStart, result.oneseoSubmissionStart());
+                assertEquals(submissionEnd, result.oneseoSubmissionEnd());
+                assertEquals(firstResults, result.firstResultsAnnouncement());
+                assertEquals(competency, result.competencyEvaluation());
+                assertEquals(interview, result.inDepthInterview());
+                assertEquals(finalResults, result.finalResultsAnnouncement());
+            }
+        }
+    }
+}

--- a/src/test/java/team/themoment/hellogsmv3/domain/common/operation/service/AnnounceFirstTestResultServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/common/operation/service/AnnounceFirstTestResultServiceTest.java
@@ -13,9 +13,10 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 
 import team.themoment.hellogsmv3.domain.common.operation.entity.OperationTestResult;
@@ -24,6 +25,7 @@ import team.themoment.hellogsmv3.domain.oneseo.repository.EntranceTestResultRepo
 import team.themoment.hellogsmv3.global.security.data.ScheduleEnvironment;
 import team.themoment.sdk.exception.ExpectedException;
 
+@ExtendWith(MockitoExtension.class)
 @DisplayName("AnnounceFirstTestResultService 클래스의")
 class AnnounceFirstTestResultServiceTest {
 
@@ -36,11 +38,6 @@ class AnnounceFirstTestResultServiceTest {
 
     @InjectMocks
     private AnnounceFirstTestResultService announceFirstTestResultService;
-
-    @BeforeEach
-    void setUp() {
-        MockitoAnnotations.openMocks(this);
-    }
 
     @Nested
     @DisplayName("execute 메서드는")
@@ -75,7 +72,6 @@ class AnnounceFirstTestResultServiceTest {
             @BeforeEach
             void setUp() {
                 given(scheduleEnv.firstResultsAnnouncement()).willReturn(LocalDateTime.now().plusDays(1));
-                given(entranceTestResultRepository.existsByFirstTestPassYnIsNull()).willReturn(false);
             }
 
             @Test
@@ -119,10 +115,11 @@ class AnnounceFirstTestResultServiceTest {
         @DisplayName("정상 조건이라면")
         class Context_valid_condition {
 
-            OperationTestResult testResult = mock(OperationTestResult.class);
+            OperationTestResult testResult;
 
             @BeforeEach
             void setUp() {
+                testResult = mock(OperationTestResult.class);
                 given(scheduleEnv.firstResultsAnnouncement()).willReturn(LocalDateTime.now().minusDays(1));
                 given(entranceTestResultRepository.existsByFirstTestPassYnIsNull()).willReturn(false);
                 given(testResult.getFirstTestResultAnnouncementYn()).willReturn(NO);

--- a/src/test/java/team/themoment/hellogsmv3/domain/common/operation/service/AnnounceFirstTestResultServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/common/operation/service/AnnounceFirstTestResultServiceTest.java
@@ -43,7 +43,7 @@ class AnnounceFirstTestResultServiceTest {
     }
 
     @Nested
-    @DisplayName("execute 메소드는")
+    @DisplayName("execute 메서드는")
     class Describe_execute {
 
         @Nested

--- a/src/test/java/team/themoment/hellogsmv3/domain/common/operation/service/AnnounceSecondTestResultServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/common/operation/service/AnnounceSecondTestResultServiceTest.java
@@ -15,9 +15,10 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 
 import team.themoment.hellogsmv3.domain.common.operation.entity.OperationTestResult;
@@ -26,6 +27,7 @@ import team.themoment.hellogsmv3.domain.oneseo.repository.EntranceTestResultRepo
 import team.themoment.hellogsmv3.global.security.data.ScheduleEnvironment;
 import team.themoment.sdk.exception.ExpectedException;
 
+@ExtendWith(MockitoExtension.class)
 @DisplayName("AnnounceSecondTestResultService 클래스의")
 class AnnounceSecondTestResultServiceTest {
 
@@ -38,11 +40,6 @@ class AnnounceSecondTestResultServiceTest {
 
     @InjectMocks
     private AnnounceSecondTestResultService announceSecondTestResultService;
-
-    @BeforeEach
-    void setUp() {
-        MockitoAnnotations.openMocks(this);
-    }
 
     @Nested
     @DisplayName("execute 메서드는")
@@ -80,13 +77,6 @@ class AnnounceSecondTestResultServiceTest {
             @BeforeEach
             void setUp() {
                 given(scheduleEnv.finalResultsAnnouncement()).willReturn(LocalDateTime.now().plusDays(1));
-                given(entranceTestResultRepository.existsByFirstTestPassYnIsNull()).willReturn(false);
-                given(entranceTestResultRepository.existsByFirstTestPassYnAndSecondTestPassYnIsNull(YES))
-                        .willReturn(false);
-                given(operationTestResultRepository.existsByFirstTestResultAnnouncementYn(NO)).willReturn(false);
-
-                OperationTestResult testResult = mock(OperationTestResult.class);
-                given(operationTestResultRepository.findTestResult()).willReturn(Optional.of(testResult));
             }
 
             @Test
@@ -137,12 +127,6 @@ class AnnounceSecondTestResultServiceTest {
             void setUp() {
                 given(scheduleEnv.finalResultsAnnouncement()).willReturn(LocalDateTime.now().minusDays(1));
                 given(entranceTestResultRepository.existsByFirstTestPassYnIsNull()).willReturn(true);
-                given(entranceTestResultRepository.existsByFirstTestPassYnAndSecondTestPassYnIsNull(YES))
-                        .willReturn(false);
-                given(operationTestResultRepository.existsByFirstTestResultAnnouncementYn(NO)).willReturn(false);
-
-                OperationTestResult testResult = mock(OperationTestResult.class);
-                given(operationTestResultRepository.findTestResult()).willReturn(Optional.of(testResult));
             }
 
             @Test
@@ -167,9 +151,6 @@ class AnnounceSecondTestResultServiceTest {
                 given(entranceTestResultRepository.existsByFirstTestPassYnAndSecondTestPassYnIsNull(YES))
                         .willReturn(false);
                 given(operationTestResultRepository.existsByFirstTestResultAnnouncementYn(NO)).willReturn(true);
-
-                OperationTestResult testResult = mock(OperationTestResult.class);
-                given(operationTestResultRepository.findTestResult()).willReturn(Optional.of(testResult));
             }
 
             @Test
@@ -193,10 +174,6 @@ class AnnounceSecondTestResultServiceTest {
                 given(entranceTestResultRepository.existsByFirstTestPassYnIsNull()).willReturn(false);
                 given(entranceTestResultRepository.existsByFirstTestPassYnAndSecondTestPassYnIsNull(YES))
                         .willReturn(true);
-                given(operationTestResultRepository.existsByFirstTestResultAnnouncementYn(NO)).willReturn(false);
-
-                OperationTestResult testResult = mock(OperationTestResult.class);
-                given(operationTestResultRepository.findTestResult()).willReturn(Optional.of(testResult));
             }
 
             @Test
@@ -221,9 +198,6 @@ class AnnounceSecondTestResultServiceTest {
                 given(entranceTestResultRepository.existsByFirstTestPassYnAndSecondTestPassYnIsNull(YES))
                         .willReturn(false);
                 given(operationTestResultRepository.existsByFirstTestResultAnnouncementYn(NO)).willReturn(true);
-
-                OperationTestResult testResult = mock(OperationTestResult.class);
-                given(operationTestResultRepository.findTestResult()).willReturn(Optional.of(testResult));
             }
 
             @Test
@@ -241,10 +215,11 @@ class AnnounceSecondTestResultServiceTest {
         @DisplayName("2차 결과 발표 기간 이후이고, 아직 2차 결과가 발표되지 않은 경우")
         class Context_valid_condition {
 
-            OperationTestResult testResult = mock(OperationTestResult.class);
+            OperationTestResult testResult;
 
             @BeforeEach
             void setUp() {
+                testResult = mock(OperationTestResult.class);
                 given(scheduleEnv.finalResultsAnnouncement()).willReturn(LocalDateTime.now().minusDays(1));
                 given(entranceTestResultRepository.existsByFirstTestPassYnIsNull()).willReturn(false);
                 given(entranceTestResultRepository.existsByFirstTestPassYnAndSecondTestPassYnIsNull(YES))

--- a/src/test/java/team/themoment/hellogsmv3/domain/common/operation/service/AnnounceSecondTestResultServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/common/operation/service/AnnounceSecondTestResultServiceTest.java
@@ -45,7 +45,7 @@ class AnnounceSecondTestResultServiceTest {
     }
 
     @Nested
-    @DisplayName("execute 메소드는")
+    @DisplayName("execute 메서드는")
     class Describe_execute {
 
         @Nested
@@ -255,7 +255,7 @@ class AnnounceSecondTestResultServiceTest {
             }
 
             @Test
-            @DisplayName("2차 결과를 발표하고 저장한다.")
+            @DisplayName("2차 결과를 발표하고 저장한다")
             void it_announces_and_saves() {
                 announceSecondTestResultService.execute();
                 verify(testResult).announceSecondTestResult();

--- a/src/test/java/team/themoment/hellogsmv3/domain/common/operation/service/QueryAnnounceTestResultServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/common/operation/service/QueryAnnounceTestResultServiceTest.java
@@ -11,9 +11,10 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 
 import team.themoment.hellogsmv3.domain.common.operation.dto.response.AnnounceTestResultResDto;
@@ -21,6 +22,7 @@ import team.themoment.hellogsmv3.domain.common.operation.entity.OperationTestRes
 import team.themoment.hellogsmv3.domain.common.operation.repository.OperationTestResultRepository;
 import team.themoment.sdk.exception.ExpectedException;
 
+@ExtendWith(MockitoExtension.class)
 @DisplayName("QueryAnnounceTestResultService 클래스의")
 class QueryAnnounceTestResultServiceTest {
 
@@ -29,11 +31,6 @@ class QueryAnnounceTestResultServiceTest {
 
     @InjectMocks
     private QueryAnnounceTestResultService queryAnnounceTestResultService;
-
-    @BeforeEach
-    void setUp() {
-        MockitoAnnotations.openMocks(this);
-    }
 
     @Nested
     @DisplayName("execute 메서드는")

--- a/src/test/java/team/themoment/hellogsmv3/domain/common/operation/service/QueryAnnounceTestResultServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/common/operation/service/QueryAnnounceTestResultServiceTest.java
@@ -22,7 +22,7 @@ import team.themoment.hellogsmv3.domain.common.operation.repository.OperationTes
 import team.themoment.sdk.exception.ExpectedException;
 
 @DisplayName("QueryAnnounceTestResultService 클래스의")
-public class QueryAnnounceTestResultServiceTest {
+class QueryAnnounceTestResultServiceTest {
 
     @Mock
     private OperationTestResultRepository operationTestResultRepository;
@@ -36,7 +36,7 @@ public class QueryAnnounceTestResultServiceTest {
     }
 
     @Nested
-    @DisplayName("execute 메소드는")
+    @DisplayName("execute 메서드는")
     class Describe_execute {
 
         @Nested
@@ -66,7 +66,7 @@ public class QueryAnnounceTestResultServiceTest {
             OperationTestResult testResult;
 
             @BeforeEach
-            void setup() {
+            void setUp() {
                 testResult = OperationTestResult.builder().firstTestResultAnnouncementYn(NO)
                         .secondTestResultAnnouncementYn(NO).build();
 

--- a/src/test/java/team/themoment/hellogsmv3/domain/common/utility/service/DeleteMemberServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/common/utility/service/DeleteMemberServiceTest.java
@@ -12,9 +12,10 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 
 import team.themoment.hellogsmv3.domain.member.entity.AuthenticationCode;
@@ -26,6 +27,7 @@ import team.themoment.hellogsmv3.domain.oneseo.entity.Oneseo;
 import team.themoment.hellogsmv3.domain.oneseo.repository.OneseoRepository;
 import team.themoment.sdk.exception.ExpectedException;
 
+@ExtendWith(MockitoExtension.class)
 @DisplayName("DeleteMemberService 클래스의")
 class DeleteMemberServiceTest {
 
@@ -38,11 +40,6 @@ class DeleteMemberServiceTest {
 
     @InjectMocks
     private DeleteMemberService deleteMemberService;
-
-    @BeforeEach
-    void setUp() {
-        MockitoAnnotations.openMocks(this);
-    }
 
     @Nested
     @DisplayName("execute 메서드는")

--- a/src/test/java/team/themoment/hellogsmv3/domain/common/utility/service/DeleteMemberServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/common/utility/service/DeleteMemberServiceTest.java
@@ -45,7 +45,7 @@ class DeleteMemberServiceTest {
     }
 
     @Nested
-    @DisplayName("execute 메소드는")
+    @DisplayName("execute 메서드는")
     class Describe_execute {
 
         private final String phoneNumber = "01012345678";

--- a/src/test/java/team/themoment/hellogsmv3/domain/common/utility/service/DeleteOneseoServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/common/utility/service/DeleteOneseoServiceTest.java
@@ -34,7 +34,7 @@ class DeleteOneseoServiceTest {
     }
 
     @Nested
-    @DisplayName("execute 메소드는")
+    @DisplayName("execute 메서드는")
     class Describe_execute {
 
         private final String submitCode = "A-1";

--- a/src/test/java/team/themoment/hellogsmv3/domain/common/utility/service/DeleteOneseoServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/common/utility/service/DeleteOneseoServiceTest.java
@@ -11,14 +11,16 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 
 import team.themoment.hellogsmv3.domain.oneseo.repository.OneseoRepository;
 import team.themoment.sdk.exception.ExpectedException;
 
+@ExtendWith(MockitoExtension.class)
 @DisplayName("DeleteOneseoService 클래스의")
 class DeleteOneseoServiceTest {
 
@@ -27,11 +29,6 @@ class DeleteOneseoServiceTest {
 
     @InjectMocks
     private DeleteOneseoService deleteOneseoService;
-
-    @BeforeEach
-    void setUp() {
-        MockitoAnnotations.openMocks(this);
-    }
 
     @Nested
     @DisplayName("execute 메서드는")

--- a/src/test/java/team/themoment/hellogsmv3/domain/common/utility/service/ModifyMemberRoleServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/common/utility/service/ModifyMemberRoleServiceTest.java
@@ -7,13 +7,13 @@ import static org.mockito.Mockito.*;
 
 import java.util.Optional;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 
 import team.themoment.hellogsmv3.domain.member.entity.Member;
@@ -21,6 +21,7 @@ import team.themoment.hellogsmv3.domain.member.entity.type.Role;
 import team.themoment.hellogsmv3.domain.member.repository.MemberRepository;
 import team.themoment.sdk.exception.ExpectedException;
 
+@ExtendWith(MockitoExtension.class)
 @DisplayName("ModifyMemberRoleService 클래스의")
 class ModifyMemberRoleServiceTest {
 
@@ -29,11 +30,6 @@ class ModifyMemberRoleServiceTest {
 
     @InjectMocks
     private ModifyMemberRoleService modifyMemberRoleService;
-
-    @BeforeEach
-    void setUp() {
-        MockitoAnnotations.openMocks(this);
-    }
 
     @Nested
     @DisplayName("execute 메서드는")

--- a/src/test/java/team/themoment/hellogsmv3/domain/common/utility/service/ModifyMemberRoleServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/common/utility/service/ModifyMemberRoleServiceTest.java
@@ -36,7 +36,7 @@ class ModifyMemberRoleServiceTest {
     }
 
     @Nested
-    @DisplayName("execute 메소드는")
+    @DisplayName("execute 메서드는")
     class Describe_execute {
 
         private final String phoneNumber = "01012345678";

--- a/src/test/java/team/themoment/hellogsmv3/domain/member/service/AuthenticateCodeServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/member/service/AuthenticateCodeServiceTest.java
@@ -13,10 +13,11 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 
 import team.themoment.hellogsmv3.domain.member.dto.request.AuthenticateCodeReqDto;
@@ -24,6 +25,7 @@ import team.themoment.hellogsmv3.domain.member.entity.AuthenticationCode;
 import team.themoment.hellogsmv3.domain.member.repository.CodeRepository;
 import team.themoment.sdk.exception.ExpectedException;
 
+@ExtendWith(MockitoExtension.class)
 @DisplayName("AuthenticateCodeService 클래스의")
 class AuthenticateCodeServiceTest {
 
@@ -32,11 +34,6 @@ class AuthenticateCodeServiceTest {
 
     @InjectMocks
     private AuthenticateCodeService authenticateCodeService;
-
-    @BeforeEach
-    void setUp() {
-        MockitoAnnotations.openMocks(this);
-    }
 
     @Nested
     @DisplayName("execute 메서드는")

--- a/src/test/java/team/themoment/hellogsmv3/domain/member/service/AuthenticateCodeServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/member/service/AuthenticateCodeServiceTest.java
@@ -25,7 +25,7 @@ import team.themoment.hellogsmv3.domain.member.repository.CodeRepository;
 import team.themoment.sdk.exception.ExpectedException;
 
 @DisplayName("AuthenticateCodeService 클래스의")
-public class AuthenticateCodeServiceTest {
+class AuthenticateCodeServiceTest {
 
     @Mock
     private CodeRepository codeRepository;
@@ -39,12 +39,11 @@ public class AuthenticateCodeServiceTest {
     }
 
     @Nested
-    @DisplayName("execute 메소드는")
+    @DisplayName("execute 메서드는")
     class Describe_execute {
 
         private final Long memberId = 1L;
         private final String validCode = "000000";
-        private final String invalidCode = "111111";
         private final AuthenticateCodeReqDto reqDto = new AuthenticateCodeReqDto(validCode);
         private AuthenticationCode authenticationCode;
 
@@ -65,7 +64,7 @@ public class AuthenticateCodeServiceTest {
             }
 
             @Test
-            @DisplayName("인증 코드를 인증 상태로 변경하고 저장한다.")
+            @DisplayName("인증 코드를 인증 상태로 변경하고 저장한다")
             void it_authenticates_code_and_saves() {
                 authenticateCodeService.execute(memberId, reqDto, SIGNUP);
 
@@ -87,7 +86,7 @@ public class AuthenticateCodeServiceTest {
             }
 
             @Test
-            @DisplayName("ExpectedException을 던진다.")
+            @DisplayName("ExpectedException을 던진다")
             void it_throws_expected_exception() {
                 ExpectedException exception = assertThrows(ExpectedException.class,
                         () -> authenticateCodeService.execute(memberId, reqDto, SIGNUP));
@@ -114,8 +113,9 @@ public class AuthenticateCodeServiceTest {
             }
 
             @Test
-            @DisplayName("ExpectedException을 던진다.")
+            @DisplayName("ExpectedException을 던진다")
             void it_throws_expected_exception() {
+                String invalidCode = "111111";
                 AuthenticateCodeReqDto invalidReqDto = new AuthenticateCodeReqDto(invalidCode);
 
                 ExpectedException exception = assertThrows(ExpectedException.class,

--- a/src/test/java/team/themoment/hellogsmv3/domain/member/service/CommonCodeServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/member/service/CommonCodeServiceTest.java
@@ -15,15 +15,17 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 
 import team.themoment.hellogsmv3.domain.member.entity.AuthenticationCode;
 import team.themoment.hellogsmv3.domain.member.repository.CodeRepository;
 import team.themoment.sdk.exception.ExpectedException;
 
+@ExtendWith(MockitoExtension.class)
 @DisplayName("CommonCodeService 클래스의")
 class CommonCodeServiceTest {
 
@@ -32,11 +34,6 @@ class CommonCodeServiceTest {
 
     @InjectMocks
     private CommonCodeService commonCodeService;
-
-    @BeforeEach
-    void setUp() {
-        MockitoAnnotations.openMocks(this);
-    }
 
     @Nested
     @DisplayName("validateAndDelete 메서드는")

--- a/src/test/java/team/themoment/hellogsmv3/domain/member/service/CommonCodeServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/member/service/CommonCodeServiceTest.java
@@ -39,7 +39,7 @@ class CommonCodeServiceTest {
     }
 
     @Nested
-    @DisplayName("validateAndDelete 메소드는")
+    @DisplayName("validateAndDelete 메서드는")
     class Describe_validateAndDelete {
 
         private final Long memberId = 1L;
@@ -91,9 +91,8 @@ class CommonCodeServiceTest {
             @Test
             @DisplayName("ExpectedException을 던진다")
             void it_throws_expected_exception() {
-                ExpectedException exception = assertThrows(ExpectedException.class, () -> {
-                    commonCodeService.validateAndDelete(memberId, validCode, validPhoneNumber, SIGNUP);
-                });
+                ExpectedException exception = assertThrows(ExpectedException.class,
+                        () -> commonCodeService.validateAndDelete(memberId, validCode, validPhoneNumber, SIGNUP));
 
                 assertEquals("사용자의 code가 존재하지 않습니다. 사용자의 ID : " + memberId, exception.getMessage());
                 assertEquals(HttpStatus.BAD_REQUEST, exception.getStatusCode());
@@ -113,9 +112,8 @@ class CommonCodeServiceTest {
             @Test
             @DisplayName("ExpectedException을 던진다")
             void it_throws_expected_exception_when_code_is_not_authenticated() {
-                ExpectedException exception = assertThrows(ExpectedException.class, () -> {
-                    commonCodeService.validateAndDelete(memberId, validCode, validPhoneNumber, SIGNUP);
-                });
+                ExpectedException exception = assertThrows(ExpectedException.class,
+                        () -> commonCodeService.validateAndDelete(memberId, validCode, validPhoneNumber, SIGNUP));
 
                 assertEquals("유효하지 않은 요청입니다. 인증받지 않은 code입니다.", exception.getMessage());
                 assertEquals(HttpStatus.BAD_REQUEST, exception.getStatusCode());
@@ -136,9 +134,8 @@ class CommonCodeServiceTest {
             @Test
             @DisplayName("ExpectedException을 던진다")
             void it_throws_expected_exception_when_code_is_invalid() {
-                ExpectedException exception = assertThrows(ExpectedException.class, () -> {
-                    commonCodeService.validateAndDelete(memberId, invalidCode, validPhoneNumber, SIGNUP);
-                });
+                ExpectedException exception = assertThrows(ExpectedException.class,
+                        () -> commonCodeService.validateAndDelete(memberId, invalidCode, validPhoneNumber, SIGNUP));
 
                 assertEquals("유효하지 않은 요청입니다. 이전 혹은 잘못된 형식의 code입니다.", exception.getMessage());
                 assertEquals(HttpStatus.BAD_REQUEST, exception.getStatusCode());
@@ -159,9 +156,8 @@ class CommonCodeServiceTest {
             @Test
             @DisplayName("ExpectedException을 던진다")
             void it_throws_expected_exception() {
-                ExpectedException exception = assertThrows(ExpectedException.class, () -> {
-                    commonCodeService.validateAndDelete(memberId, validCode, invalidPhoneNumber, SIGNUP);
-                });
+                ExpectedException exception = assertThrows(ExpectedException.class,
+                        () -> commonCodeService.validateAndDelete(memberId, validCode, invalidPhoneNumber, SIGNUP));
 
                 assertEquals("유효하지 않은 요청입니다. code인증에 사용되었던 전화번호와 요청에 사용한 전화번호가 일치하지 않습니다.", exception.getMessage());
                 assertEquals(HttpStatus.BAD_REQUEST, exception.getStatusCode());

--- a/src/test/java/team/themoment/hellogsmv3/domain/member/service/CreateMemberServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/member/service/CreateMemberServiceTest.java
@@ -16,9 +16,10 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 
 import team.themoment.hellogsmv3.domain.member.dto.request.CreateMemberReqDto;
@@ -31,6 +32,7 @@ import team.themoment.hellogsmv3.domain.oneseo.repository.EntranceTestResultRepo
 import team.themoment.hellogsmv3.global.security.data.ScheduleEnvironment;
 import team.themoment.sdk.exception.ExpectedException;
 
+@ExtendWith(MockitoExtension.class)
 @DisplayName("CreateMemberService 클래스의")
 class CreateMemberServiceTest {
 
@@ -46,11 +48,6 @@ class CreateMemberServiceTest {
     private CommonCodeService commonCodeService;
     @InjectMocks
     private CreateMemberService createMemberService;
-
-    @BeforeEach
-    void setUp() {
-        MockitoAnnotations.openMocks(this);
-    }
 
     @Nested
     @DisplayName("execute 메서드는")

--- a/src/test/java/team/themoment/hellogsmv3/domain/member/service/CreateMemberServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/member/service/CreateMemberServiceTest.java
@@ -28,7 +28,6 @@ import team.themoment.hellogsmv3.domain.member.entity.type.Role;
 import team.themoment.hellogsmv3.domain.member.entity.type.Sex;
 import team.themoment.hellogsmv3.domain.member.repository.MemberRepository;
 import team.themoment.hellogsmv3.domain.oneseo.repository.EntranceTestResultRepository;
-import team.themoment.hellogsmv3.domain.oneseo.repository.OneseoRepository;
 import team.themoment.hellogsmv3.global.security.data.ScheduleEnvironment;
 import team.themoment.sdk.exception.ExpectedException;
 
@@ -42,8 +41,6 @@ class CreateMemberServiceTest {
     @Mock
     private ScheduleEnvironment scheduleEnvironment;
     @Mock
-    private OneseoRepository oneseoRepository;
-    @Mock
     private EntranceTestResultRepository entranceTestResultRepository;
     @Mock
     private CommonCodeService commonCodeService;
@@ -56,7 +53,7 @@ class CreateMemberServiceTest {
     }
 
     @Nested
-    @DisplayName("execute 메소드는")
+    @DisplayName("execute 메서드는")
     class Describe_execute {
 
         private final Long memberId = 1L;
@@ -108,7 +105,7 @@ class CreateMemberServiceTest {
 
             @BeforeEach
             void setUp() {
-                when(memberService.findByIdOrThrow(memberId)).thenThrow(
+                given(memberService.findByIdOrThrow(memberId)).willThrow(
                         new ExpectedException("존재하지 않는 지원자입니다. member ID: " + memberId, HttpStatus.NOT_FOUND));
                 willDoNothing().given(commonCodeService)
                         .validateAndDelete(memberId, reqDto.code(), reqDto.phoneNumber(), SIGNUP);

--- a/src/test/java/team/themoment/hellogsmv3/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/member/service/MemberServiceTest.java
@@ -20,7 +20,7 @@ import team.themoment.hellogsmv3.domain.member.repository.MemberRepository;
 import team.themoment.sdk.exception.ExpectedException;
 
 @DisplayName("MemberService 클래스의")
-public class MemberServiceTest {
+class MemberServiceTest {
 
     @Mock
     private MemberRepository memberRepository;
@@ -34,7 +34,7 @@ public class MemberServiceTest {
     }
 
     @Nested
-    @DisplayName("findByIdOrThrow 메소드는")
+    @DisplayName("findByIdOrThrow 메서드는")
     class Describe_findByIdOrThrow {
 
         private final Long memberId = 1L;
@@ -50,7 +50,7 @@ public class MemberServiceTest {
             }
 
             @Test
-            @DisplayName("회원 정보를 반환한다.")
+            @DisplayName("회원 정보를 반환한다")
             void it_returns_member() {
                 Member foundMember = memberService.findByIdOrThrow(memberId);
                 assertEquals(member, foundMember);
@@ -67,7 +67,7 @@ public class MemberServiceTest {
             }
 
             @Test
-            @DisplayName("ExpectedException을 던진다.")
+            @DisplayName("ExpectedException을 던진다")
             void it_throws_expected_exception() {
                 ExpectedException exception = assertThrows(ExpectedException.class,
                         () -> memberService.findByIdOrThrow(memberId));

--- a/src/test/java/team/themoment/hellogsmv3/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/member/service/MemberServiceTest.java
@@ -10,15 +10,17 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 
 import team.themoment.hellogsmv3.domain.member.entity.Member;
 import team.themoment.hellogsmv3.domain.member.repository.MemberRepository;
 import team.themoment.sdk.exception.ExpectedException;
 
+@ExtendWith(MockitoExtension.class)
 @DisplayName("MemberService 클래스의")
 class MemberServiceTest {
 
@@ -27,11 +29,6 @@ class MemberServiceTest {
 
     @InjectMocks
     private MemberService memberService;
-
-    @BeforeEach
-    void setUp() {
-        MockitoAnnotations.openMocks(this);
-    }
 
     @Nested
     @DisplayName("findByIdOrThrow 메서드는")

--- a/src/test/java/team/themoment/hellogsmv3/domain/member/service/QueryCheckDuplicateMemberServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/member/service/QueryCheckDuplicateMemberServiceTest.java
@@ -36,7 +36,7 @@ class QueryCheckDuplicateMemberServiceTest {
         @DisplayName("파라미터로 받은 전화번호가 주어졌을 때")
         class Context_with_phone_number {
             @Test
-            @DisplayName("중복된 전화번호라면 YES를 반환한다.")
+            @DisplayName("중복된 전화번호라면 YES를 반환한다")
             void it_duplicate_return_yes() {
                 // given
                 given(memberRepository.existsByPhoneNumber(phoneNumber)).willReturn(true);
@@ -47,7 +47,7 @@ class QueryCheckDuplicateMemberServiceTest {
             }
 
             @Test
-            @DisplayName("중복된 전화번호가 아니라면 NO를 반환한다.")
+            @DisplayName("중복된 전화번호가 아니라면 NO를 반환한다")
             void it_not_duplicate_return_no() {
                 // given
                 given(memberRepository.existsByPhoneNumber(phoneNumber)).willReturn(false);

--- a/src/test/java/team/themoment/hellogsmv3/domain/member/service/QueryCheckDuplicateMemberServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/member/service/QueryCheckDuplicateMemberServiceTest.java
@@ -4,28 +4,24 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.BDDMockito.given;
 import static team.themoment.hellogsmv3.domain.oneseo.entity.type.YesNo.*;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import team.themoment.hellogsmv3.domain.member.dto.response.FoundDuplicateMemberResDto;
 import team.themoment.hellogsmv3.domain.member.repository.MemberRepository;
 
+@ExtendWith(MockitoExtension.class)
 @DisplayName("QueryCheckDuplicateMemberService 클래스의")
 class QueryCheckDuplicateMemberServiceTest {
     @Mock
     private MemberRepository memberRepository;
     @InjectMocks
     private QueryCheckDuplicateMemberService queryCheckDuplicateMemberService;
-
-    @BeforeEach
-    void setUp() {
-        MockitoAnnotations.openMocks(this);
-    }
 
     @Nested
     @DisplayName("execute 메서드는")

--- a/src/test/java/team/themoment/hellogsmv3/domain/member/service/QueryMemberAuthInfoByIdServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/member/service/QueryMemberAuthInfoByIdServiceTest.java
@@ -9,9 +9,10 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 
 import team.themoment.hellogsmv3.domain.member.dto.response.FoundMemberAuthInfoResDto;
@@ -21,6 +22,7 @@ import team.themoment.hellogsmv3.domain.member.entity.type.Role;
 import team.themoment.hellogsmv3.domain.member.repository.MemberRepository;
 import team.themoment.sdk.exception.ExpectedException;
 
+@ExtendWith(MockitoExtension.class)
 @DisplayName("QueryMemberAuthInfoByIdService 클래스의")
 class QueryMemberAuthInfoByIdServiceTest {
 
@@ -29,11 +31,6 @@ class QueryMemberAuthInfoByIdServiceTest {
 
     @InjectMocks
     private QueryMemberAuthInfoByIdService queryMemberAuthInfoByIdService;
-
-    @BeforeEach
-    void setUp() {
-        MockitoAnnotations.openMocks(this);
-    }
 
     @Nested
     @DisplayName("execute 메서드는")

--- a/src/test/java/team/themoment/hellogsmv3/domain/member/service/QueryMemberAuthInfoByIdServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/member/service/QueryMemberAuthInfoByIdServiceTest.java
@@ -22,7 +22,7 @@ import team.themoment.hellogsmv3.domain.member.repository.MemberRepository;
 import team.themoment.sdk.exception.ExpectedException;
 
 @DisplayName("QueryMemberAuthInfoByIdService 클래스의")
-public class QueryMemberAuthInfoByIdServiceTest {
+class QueryMemberAuthInfoByIdServiceTest {
 
     @Mock
     private MemberRepository memberRepository;
@@ -36,7 +36,7 @@ public class QueryMemberAuthInfoByIdServiceTest {
     }
 
     @Nested
-    @DisplayName("execute 메소드는")
+    @DisplayName("execute 메서드는")
     class Describe_execute {
 
         private final Long memberId = 1L;
@@ -53,7 +53,7 @@ public class QueryMemberAuthInfoByIdServiceTest {
             }
 
             @Test
-            @DisplayName("회원 인증 정보를 반환한다.")
+            @DisplayName("회원 인증 정보를 반환한다")
             void it_return_member_auth_info() {
                 FoundMemberAuthInfoResDto result = queryMemberAuthInfoByIdService.execute(memberId);
 

--- a/src/test/java/team/themoment/hellogsmv3/domain/member/service/QueryMemberByIdServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/member/service/QueryMemberByIdServiceTest.java
@@ -36,7 +36,7 @@ class QueryMemberByIdServiceTest {
     }
 
     @Nested
-    @DisplayName("execute 메소드는")
+    @DisplayName("execute 메서드는")
     class Describe_execute {
 
         private final Long memberId = 1L;
@@ -80,9 +80,8 @@ class QueryMemberByIdServiceTest {
             @Test
             @DisplayName("ExpectedException을 던진다")
             void it_throws_expected_exception() {
-                ExpectedException exception = assertThrows(ExpectedException.class, () -> {
-                    queryMemberByIdService.execute(memberId);
-                });
+                ExpectedException exception = assertThrows(ExpectedException.class,
+                        () -> queryMemberByIdService.execute(memberId));
 
                 assertEquals("존재하지 않는 지원자입니다. member ID: " + memberId, exception.getMessage());
                 assertEquals(HttpStatus.NOT_FOUND, exception.getStatusCode());

--- a/src/test/java/team/themoment/hellogsmv3/domain/member/service/QueryMemberByIdServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/member/service/QueryMemberByIdServiceTest.java
@@ -10,9 +10,10 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 
 import team.themoment.hellogsmv3.domain.member.dto.response.FoundMemberResDto;
@@ -21,6 +22,7 @@ import team.themoment.hellogsmv3.domain.member.entity.type.Sex;
 import team.themoment.hellogsmv3.domain.member.repository.MemberRepository;
 import team.themoment.sdk.exception.ExpectedException;
 
+@ExtendWith(MockitoExtension.class)
 @DisplayName("QueryMemberByIdService 클래스의")
 class QueryMemberByIdServiceTest {
 
@@ -29,11 +31,6 @@ class QueryMemberByIdServiceTest {
 
     @InjectMocks
     private QueryMemberByIdService queryMemberByIdService;
-
-    @BeforeEach
-    void setUp() {
-        MockitoAnnotations.openMocks(this);
-    }
 
     @Nested
     @DisplayName("execute 메서드는")

--- a/src/test/java/team/themoment/hellogsmv3/domain/member/service/QueryMyFirstTestResultServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/member/service/QueryMyFirstTestResultServiceTest.java
@@ -19,10 +19,7 @@ import team.themoment.hellogsmv3.domain.oneseo.entity.type.YesNo;
 import team.themoment.hellogsmv3.domain.oneseo.service.OneseoService;
 
 @DisplayName("QueryMyFirstTestResultService 클래스의")
-public class QueryMyFirstTestResultServiceTest {
-    @Mock
-    private MemberService memberService;
-
+class QueryMyFirstTestResultServiceTest {
     @Mock
     private OneseoService oneseoService;
 
@@ -35,16 +32,15 @@ public class QueryMyFirstTestResultServiceTest {
     }
 
     @Nested
-    @DisplayName("execute 메소드는")
+    @DisplayName("execute 메서드는")
     class Describe_execute {
 
         private final Long memberId = 1L;
-        private Member member;
         private Oneseo oneseo;
 
         @BeforeEach
         void setUp() {
-            member = Member.builder().id(memberId).build();
+            Member member = Member.builder().id(memberId).build();
 
             oneseo = Oneseo.builder().member(member)
                     .entranceTestResult(EntranceTestResult.builder().firstTestPassYn(YesNo.YES).build()).build();

--- a/src/test/java/team/themoment/hellogsmv3/domain/member/service/QueryMyFirstTestResultServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/member/service/QueryMyFirstTestResultServiceTest.java
@@ -7,9 +7,10 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import team.themoment.hellogsmv3.domain.member.dto.response.FoundMemberFirstTestResDto;
 import team.themoment.hellogsmv3.domain.member.entity.Member;
@@ -18,6 +19,7 @@ import team.themoment.hellogsmv3.domain.oneseo.entity.Oneseo;
 import team.themoment.hellogsmv3.domain.oneseo.entity.type.YesNo;
 import team.themoment.hellogsmv3.domain.oneseo.service.OneseoService;
 
+@ExtendWith(MockitoExtension.class)
 @DisplayName("QueryMyFirstTestResultService 클래스의")
 class QueryMyFirstTestResultServiceTest {
     @Mock
@@ -25,11 +27,6 @@ class QueryMyFirstTestResultServiceTest {
 
     @InjectMocks
     private QueryMyFirstTestResultService queryMyFirstTestResultService;
-
-    @BeforeEach
-    void setUp() {
-        MockitoAnnotations.openMocks(this);
-    }
 
     @Nested
     @DisplayName("execute 메서드는")

--- a/src/test/java/team/themoment/hellogsmv3/domain/member/service/QueryMySecondTestResultServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/member/service/QueryMySecondTestResultServiceTest.java
@@ -7,9 +7,10 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import team.themoment.hellogsmv3.domain.member.dto.response.FoundMemberSecondTestResDto;
 import team.themoment.hellogsmv3.domain.member.entity.Member;
@@ -19,6 +20,7 @@ import team.themoment.hellogsmv3.domain.oneseo.entity.type.Major;
 import team.themoment.hellogsmv3.domain.oneseo.entity.type.YesNo;
 import team.themoment.hellogsmv3.domain.oneseo.service.OneseoService;
 
+@ExtendWith(MockitoExtension.class)
 @DisplayName("QueryMySecondTestResultService 클래스의")
 class QueryMySecondTestResultServiceTest {
 
@@ -27,11 +29,6 @@ class QueryMySecondTestResultServiceTest {
 
     @InjectMocks
     private QueryMySecondTestResultService queryMySecondTestResultService;
-
-    @BeforeEach
-    void setUp() {
-        MockitoAnnotations.openMocks(this);
-    }
 
     @Nested
     @DisplayName("execute 메서드는")

--- a/src/test/java/team/themoment/hellogsmv3/domain/member/service/QueryMySecondTestResultServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/member/service/QueryMySecondTestResultServiceTest.java
@@ -20,9 +20,7 @@ import team.themoment.hellogsmv3.domain.oneseo.entity.type.YesNo;
 import team.themoment.hellogsmv3.domain.oneseo.service.OneseoService;
 
 @DisplayName("QueryMySecondTestResultService 클래스의")
-public class QueryMySecondTestResultServiceTest {
-    @Mock
-    private MemberService memberService;
+class QueryMySecondTestResultServiceTest {
 
     @Mock
     private OneseoService oneseoService;
@@ -36,16 +34,15 @@ public class QueryMySecondTestResultServiceTest {
     }
 
     @Nested
-    @DisplayName("execute 메소드는")
+    @DisplayName("execute 메서드는")
     class Describe_execute {
 
         private final Long memberId = 1L;
-        private Member member;
         private Oneseo oneseo;
 
         @BeforeEach
         void setUp() {
-            member = Member.builder().id(memberId).build();
+            Member member = Member.builder().id(memberId).build();
 
             oneseo = Oneseo.builder().member(member)
                     .entranceTestResult(EntranceTestResult.builder().secondTestPassYn(YesNo.YES).build())

--- a/src/test/java/team/themoment/hellogsmv3/domain/member/service/impl/GenerateCodeServiceImplTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/member/service/impl/GenerateCodeServiceImplTest.java
@@ -11,7 +11,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.*;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 
 import team.themoment.hellogsmv3.domain.member.dto.request.GenerateCodeReqDto;
@@ -20,6 +22,7 @@ import team.themoment.hellogsmv3.domain.member.repository.CodeRepository;
 import team.themoment.hellogsmv3.domain.member.service.SendCodeNotificationService;
 import team.themoment.sdk.exception.ExpectedException;
 
+@ExtendWith(MockitoExtension.class)
 @DisplayName("GenerateTestResultCodeServiceImpl 클래스의")
 class GenerateCodeServiceImplTest {
 
@@ -31,11 +34,6 @@ class GenerateCodeServiceImplTest {
 
     @InjectMocks
     private GenerateCodeServiceImpl generateCodeServiceImpl;
-
-    @BeforeEach
-    void setUp() {
-        MockitoAnnotations.openMocks(this);
-    }
 
     @Nested
     @DisplayName("execute 메서드는")

--- a/src/test/java/team/themoment/hellogsmv3/domain/member/service/impl/GenerateTestCodeServiceImplTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/member/service/impl/GenerateTestCodeServiceImplTest.java
@@ -11,12 +11,15 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.*;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import team.themoment.hellogsmv3.domain.member.dto.request.GenerateCodeReqDto;
 import team.themoment.hellogsmv3.domain.member.entity.AuthenticationCode;
 import team.themoment.hellogsmv3.domain.member.repository.CodeRepository;
 
+@ExtendWith(MockitoExtension.class)
 @DisplayName("GenerateTestCodeServiceImpl 클래스의")
 class GenerateTestCodeServiceImplTest {
 
@@ -25,11 +28,6 @@ class GenerateTestCodeServiceImplTest {
 
     @InjectMocks
     private GenerateTestCodeServiceImpl generateTestCodeServiceImpl;
-
-    @BeforeEach
-    void setUp() {
-        MockitoAnnotations.openMocks(this);
-    }
 
     @Nested
     @DisplayName("execute 메서드는")

--- a/src/test/java/team/themoment/hellogsmv3/domain/oneseo/annotation/DesiredMajorsValidatorTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/oneseo/annotation/DesiredMajorsValidatorTest.java
@@ -2,6 +2,7 @@ package team.themoment.hellogsmv3.domain.oneseo.annotation;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.*;
 import static team.themoment.hellogsmv3.domain.oneseo.entity.type.GraduationType.*;
 import static team.themoment.hellogsmv3.domain.oneseo.entity.type.Major.*;
@@ -19,11 +20,10 @@ import team.themoment.hellogsmv3.domain.oneseo.dto.request.OneseoReqDto;
 import team.themoment.hellogsmv3.domain.oneseo.entity.type.Major;
 
 @DisplayName("DesiredMajorsValidator 클래스의")
-public class DesiredMajorsValidatorTest {
+class DesiredMajorsValidatorTest {
 
     private DesiredMajorsValidator validator;
     private ConstraintValidatorContext context;
-    private ValidDesiredMajors annotation;
 
     @BeforeEach
     void setUp() {
@@ -32,18 +32,18 @@ public class DesiredMajorsValidatorTest {
         @ValidDesiredMajors
         class Dummy {
         }
-        annotation = Dummy.class.getAnnotation(ValidDesiredMajors.class);
+        ValidDesiredMajors annotation = Dummy.class.getAnnotation(ValidDesiredMajors.class);
         validator.initialize(annotation);
 
         context = Mockito.mock(ConstraintValidatorContext.class);
         ConstraintValidatorContext.ConstraintViolationBuilder builder = Mockito
                 .mock(ConstraintValidatorContext.ConstraintViolationBuilder.class);
-        when(context.buildConstraintViolationWithTemplate(anyString())).thenReturn(builder);
-        when(builder.addConstraintViolation()).thenReturn(context);
+        given(context.buildConstraintViolationWithTemplate(anyString())).willReturn(builder);
+        given(builder.addConstraintViolation()).willReturn(context);
     }
 
     @Nested
-    @DisplayName("isValid 메소드는")
+    @DisplayName("isValid 메서드는")
     class Describe_isValid {
 
         private OneseoReqDto createValidOneseoReqDto(Major first, Major second, Major third) {

--- a/src/test/java/team/themoment/hellogsmv3/domain/oneseo/annotation/SubjectNameValidatorTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/oneseo/annotation/SubjectNameValidatorTest.java
@@ -1,6 +1,7 @@
 package team.themoment.hellogsmv3.domain.oneseo.annotation;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.*;
 
 import java.util.Arrays;
@@ -13,9 +14,9 @@ import jakarta.validation.ConstraintValidatorContext;
 import team.themoment.hellogsmv3.domain.oneseo.dto.request.MiddleSchoolAchievementReqDto;
 
 @DisplayName("SubjectNameValidator 클래스의")
-public class SubjectNameValidatorTest {
+class SubjectNameValidatorTest {
 
-    @DisplayName("isValid 메소드는")
+    @DisplayName("isValid 메서드는")
     @Nested
     class Describe_isValid {
 
@@ -35,8 +36,8 @@ public class SubjectNameValidatorTest {
             context = Mockito.mock(ConstraintValidatorContext.class);
             ConstraintValidatorContext.ConstraintViolationBuilder builder = Mockito
                     .mock(ConstraintValidatorContext.ConstraintViolationBuilder.class);
-            when(context.buildConstraintViolationWithTemplate(anyString())).thenReturn(builder);
-            when(builder.addConstraintViolation()).thenReturn(context);
+            given(context.buildConstraintViolationWithTemplate(anyString())).willReturn(builder);
+            given(builder.addConstraintViolation()).willReturn(context);
         }
 
         @DisplayName("모든 과목이 중복되지 않으면")
@@ -53,7 +54,7 @@ public class SubjectNameValidatorTest {
                         .newSubjects(newSubjects).artsPhysicalSubjects(artsPhysicalSubjects).build();
             }
 
-            @DisplayName("ConstraintViolation을 발생시키지 않는다.")
+            @DisplayName("ConstraintViolation을 발생시키지 않는다")
             @Test
             void it_doesnt_make_constraint_violation() {
                 boolean result = validator.isValid(middleSchoolAchievementReqDto, context);
@@ -75,7 +76,7 @@ public class SubjectNameValidatorTest {
                         .newSubjects(newSubjects).artsPhysicalSubjects(artsPhysicalSubjects).build();
             }
 
-            @DisplayName("ConstraintViolation을 발생시킨다.")
+            @DisplayName("ConstraintViolation을 발생시킨다")
             @Test
             void it_makes_constraint_violation() {
                 boolean result = validator.isValid(middleSchoolAchievementReqDto, context);
@@ -95,7 +96,7 @@ public class SubjectNameValidatorTest {
                         .newSubjects(null).artsPhysicalSubjects(Arrays.asList("체육", "미술", "음악")).build();
             }
 
-            @DisplayName("ConstraintViolation을 발생시키지 않는다.")
+            @DisplayName("ConstraintViolation을 발생시키지 않는다")
             @Test
             void it_doesnt_make_constraint_violation() {
                 boolean result = validator.isValid(middleSchoolAchievementReqDto, context);

--- a/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/ApproveOneseoEditPermissionServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/ApproveOneseoEditPermissionServiceTest.java
@@ -10,15 +10,17 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 
 import team.themoment.hellogsmv3.domain.oneseo.entity.Oneseo;
 import team.themoment.hellogsmv3.domain.oneseo.entity.type.OneseoEditStatus;
 import team.themoment.sdk.exception.ExpectedException;
 
+@ExtendWith(MockitoExtension.class)
 @DisplayName("ApproveOneseoEditPermissionService 클래스의")
 class ApproveOneseoEditPermissionServiceTest {
 
@@ -27,11 +29,6 @@ class ApproveOneseoEditPermissionServiceTest {
 
     @InjectMocks
     private ApproveOneseoEditPermissionService service;
-
-    @BeforeEach
-    void setUp() {
-        MockitoAnnotations.openMocks(this);
-    }
 
     @Nested
     @DisplayName("execute 메서드는")

--- a/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/CreateOneseoServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/CreateOneseoServiceTest.java
@@ -21,6 +21,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.http.HttpStatus;
 
 import team.themoment.hellogsmv3.domain.member.entity.Member;
@@ -52,9 +53,15 @@ class CreateOneseoServiceTest {
     @Mock
     private EntranceTestResultRepository entranceTestResultRepository;
     @Mock
+    private EntranceTestFactorsDetailRepository entranceTestFactorsDetailRepository;
+    @Mock
     private MemberService memberService;
     @Mock
     private LambdaScoreCalculatorClient lambdaScoreCalculatorClient;
+    @Mock
+    private OneseoService oneseoService;
+    @Mock
+    private ApplicationEventPublisher applicationEventPublisher;
 
     @InjectMocks
     private CreateOneseoService createOneseoService;

--- a/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/CreateOneseoServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/CreateOneseoServiceTest.java
@@ -1,8 +1,8 @@
 package team.themoment.hellogsmv3.domain.oneseo.service;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willThrow;
 import static org.mockito.Mockito.*;
 import static team.themoment.hellogsmv3.domain.oneseo.entity.type.GraduationType.*;
 import static team.themoment.hellogsmv3.domain.oneseo.entity.type.Major.*;
@@ -78,7 +78,7 @@ class CreateOneseoServiceTest {
 
         List<Integer> achievement = Arrays.asList(5, 5, 5, 5, 5, 5, 5, 5, 5);
         List<String> generalSubjects = Arrays.asList("국어", "도덕", "사회", "역사", "수학", "과학", "기술가정", "영어");
-        List<String> newSubjects = Arrays.asList("프로그래밍");
+        List<String> newSubjects = List.of("프로그래밍");
         List<Integer> artsPhysicalAchievement = Arrays.asList(5, 5, 5, 5, 5, 5, 5, 5, 5);
         List<String> artsPhysicalSubjects = Arrays.asList("체육", "미술", "음악");
         List<Integer> absentDays = Arrays.asList(0, 0, 0);
@@ -198,7 +198,7 @@ class CreateOneseoServiceTest {
                 assertEquals(volunteerTime, capturedAchievement.getVolunteerTime());
                 assertEquals(liberalSystem, capturedAchievement.getLiberalSystem());
                 assertEquals(freeSemester, capturedAchievement.getFreeSemester());
-                assertEquals(null, capturedAchievement.getGedAvgScore());
+                assertNull(capturedAchievement.getGedAvgScore());
             }
         }
 
@@ -210,8 +210,8 @@ class CreateOneseoServiceTest {
             void setUp() {
                 given(reqDto.graduationType()).willReturn(GRADUATE);
 
-                doThrow(new ExpectedException("존재하지 않는 지원자입니다. member ID: " + memberId, HttpStatus.NOT_FOUND))
-                        .when(memberService).findByIdForUpdateOrThrow(memberId);
+                willThrow(new ExpectedException("존재하지 않는 지원자입니다. member ID: " + memberId, HttpStatus.NOT_FOUND))
+                        .given(memberService).findByIdForUpdateOrThrow(memberId);
             }
 
             @Test

--- a/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/CreateOneseoServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/CreateOneseoServiceTest.java
@@ -16,11 +16,11 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
-import org.springframework.context.ApplicationEventPublisher;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 
 import team.themoment.hellogsmv3.domain.member.entity.Member;
@@ -39,6 +39,7 @@ import team.themoment.hellogsmv3.global.thirdParty.feign.client.dto.request.Lamb
 import team.themoment.hellogsmv3.global.thirdParty.feign.client.lambda.LambdaScoreCalculatorClient;
 import team.themoment.sdk.exception.ExpectedException;
 
+@ExtendWith(MockitoExtension.class)
 @DisplayName("CreateOneseoService 클래스의")
 class CreateOneseoServiceTest {
 
@@ -51,23 +52,12 @@ class CreateOneseoServiceTest {
     @Mock
     private EntranceTestResultRepository entranceTestResultRepository;
     @Mock
-    private EntranceTestFactorsDetailRepository entranceTestFactorsDetailRepository;
-    @Mock
     private MemberService memberService;
-    @Mock
-    private OneseoService oneseoService;
-    @Mock
-    private ApplicationEventPublisher applicationEventPublisher;
     @Mock
     private LambdaScoreCalculatorClient lambdaScoreCalculatorClient;
 
     @InjectMocks
     private CreateOneseoService createOneseoService;
-
-    @BeforeEach
-    void setUp() {
-        MockitoAnnotations.openMocks(this);
-    }
 
     @Nested
     @DisplayName("execute 메서드는")
@@ -261,7 +251,7 @@ class CreateOneseoServiceTest {
                 Member existingMember = mock(Member.class);
 
                 given(reqDto.graduationType()).willReturn(GRADUATE);
-                given(memberService.findByIdOrThrow(memberId)).willReturn(existingMember);
+                given(memberService.findByIdForUpdateOrThrow(memberId)).willReturn(existingMember);
                 given(oneseoRepository.existsByMember(existingMember)).willReturn(false);
                 given(reqDto.middleSchoolAchievement()).willReturn(invalidMiddleSchoolAchievementReqDto);
             }

--- a/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/DownloadExcelServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/DownloadExcelServiceTest.java
@@ -33,7 +33,7 @@ import team.themoment.hellogsmv3.domain.oneseo.entity.type.*;
 import team.themoment.hellogsmv3.domain.oneseo.repository.OneseoRepository;
 
 @DisplayName("DownloadExcelService 클래스의")
-public class DownloadExcelServiceTest {
+class DownloadExcelServiceTest {
 
     @Mock
     private OneseoRepository oneseoRepository;
@@ -78,7 +78,7 @@ public class DownloadExcelServiceTest {
     }
 
     @Nested
-    @DisplayName("execute 메소드는")
+    @DisplayName("execute 메서드는")
     class Describe_execute {
 
         @Nested

--- a/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/DownloadExcelServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/DownloadExcelServiceTest.java
@@ -19,9 +19,10 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import team.themoment.hellogsmv3.domain.member.entity.Member;
 import team.themoment.hellogsmv3.domain.member.entity.type.Sex;
@@ -32,6 +33,7 @@ import team.themoment.hellogsmv3.domain.oneseo.entity.OneseoPrivacyDetail;
 import team.themoment.hellogsmv3.domain.oneseo.entity.type.*;
 import team.themoment.hellogsmv3.domain.oneseo.repository.OneseoRepository;
 
+@ExtendWith(MockitoExtension.class)
 @DisplayName("DownloadExcelService 클래스의")
 class DownloadExcelServiceTest {
 
@@ -71,11 +73,6 @@ class DownloadExcelServiceTest {
             "담임연락처",
             "1차전형결과",
             "2차전형결과");
-
-    @BeforeEach
-    void setUp() {
-        MockitoAnnotations.openMocks(this);
-    }
 
     @Nested
     @DisplayName("execute 메서드는")

--- a/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyCompetencyEvaluationScoreServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyCompetencyEvaluationScoreServiceTest.java
@@ -11,9 +11,10 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 
 import team.themoment.hellogsmv3.domain.member.entity.Member;
@@ -23,6 +24,7 @@ import team.themoment.hellogsmv3.domain.oneseo.entity.Oneseo;
 import team.themoment.hellogsmv3.domain.oneseo.repository.EntranceTestResultRepository;
 import team.themoment.sdk.exception.ExpectedException;
 
+@ExtendWith(MockitoExtension.class)
 @DisplayName("ModifyCompetencyEvaluationScoreService 클래스의")
 class ModifyCompetencyEvaluationScoreServiceTest {
 
@@ -33,11 +35,6 @@ class ModifyCompetencyEvaluationScoreServiceTest {
 
     @InjectMocks
     private ModifyCompetencyEvaluationScoreService modifyCompetencyEvaluationScoreService;
-
-    @BeforeEach
-    void setUp() {
-        MockitoAnnotations.openMocks(this);
-    }
 
     @Nested
     @DisplayName("execute 메서드는")

--- a/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyCompetencyEvaluationScoreServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyCompetencyEvaluationScoreServiceTest.java
@@ -17,7 +17,6 @@ import org.mockito.MockitoAnnotations;
 import org.springframework.http.HttpStatus;
 
 import team.themoment.hellogsmv3.domain.member.entity.Member;
-import team.themoment.hellogsmv3.domain.member.service.MemberService;
 import team.themoment.hellogsmv3.domain.oneseo.dto.request.CompetencyEvaluationScoreReqDto;
 import team.themoment.hellogsmv3.domain.oneseo.entity.EntranceTestResult;
 import team.themoment.hellogsmv3.domain.oneseo.entity.Oneseo;
@@ -25,10 +24,8 @@ import team.themoment.hellogsmv3.domain.oneseo.repository.EntranceTestResultRepo
 import team.themoment.sdk.exception.ExpectedException;
 
 @DisplayName("ModifyCompetencyEvaluationScoreService 클래스의")
-public class ModifyCompetencyEvaluationScoreServiceTest {
+class ModifyCompetencyEvaluationScoreServiceTest {
 
-    @Mock
-    private MemberService memberService;
     @Mock
     private OneseoService oneseoService;
     @Mock
@@ -43,7 +40,7 @@ public class ModifyCompetencyEvaluationScoreServiceTest {
     }
 
     @Nested
-    @DisplayName("execute 메소드는")
+    @DisplayName("execute 메서드는")
     class Describe_execute {
         private final Long memberId = 1L;
         private final BigDecimal newScore = BigDecimal.valueOf(85);
@@ -66,7 +63,7 @@ public class ModifyCompetencyEvaluationScoreServiceTest {
             }
 
             @Test
-            @DisplayName("역량검사 점수를 저장한다.")
+            @DisplayName("역량검사 점수를 저장한다")
             void it_save_competency_evaluation_score() {
                 CompetencyEvaluationScoreReqDto competencyEvaluationScoreReqDto = new CompetencyEvaluationScoreReqDto(
                         newScore);

--- a/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyEntranceIntentionServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyEntranceIntentionServiceTest.java
@@ -16,7 +16,6 @@ import org.mockito.MockitoAnnotations;
 import org.springframework.http.HttpStatus;
 
 import team.themoment.hellogsmv3.domain.member.entity.Member;
-import team.themoment.hellogsmv3.domain.member.service.MemberService;
 import team.themoment.hellogsmv3.domain.oneseo.dto.request.EntranceIntentionReqDto;
 import team.themoment.hellogsmv3.domain.oneseo.entity.Oneseo;
 import team.themoment.hellogsmv3.domain.oneseo.entity.type.Major;
@@ -25,10 +24,7 @@ import team.themoment.hellogsmv3.domain.oneseo.repository.OneseoRepository;
 import team.themoment.sdk.exception.ExpectedException;
 
 @DisplayName("ModifyEntranceIntentionService 클래스의")
-public class ModifyEntranceIntentionServiceTest {
-
-    @Mock
-    private MemberService memberService;
+class ModifyEntranceIntentionServiceTest {
     @Mock
     private OneseoService oneseoService;
     @Mock
@@ -43,7 +39,7 @@ public class ModifyEntranceIntentionServiceTest {
     }
 
     @Nested
-    @DisplayName("execute 메소드는")
+    @DisplayName("execute 메서드는")
     class Describe_execute {
 
         private final Long memberId = 1L;
@@ -80,7 +76,7 @@ public class ModifyEntranceIntentionServiceTest {
                     }
 
                     @Test
-                    @DisplayName("입학 의사 여부를 수정하고 저장한다.")
+                    @DisplayName("입학 의사 여부를 수정하고 저장한다")
                     void it_saves_entrance_intention() {
                         EntranceIntentionReqDto reqDto = new EntranceIntentionReqDto(targetYn);
                         modifyEntranceIntentionService.execute(memberId, reqDto);

--- a/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyEntranceIntentionServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyEntranceIntentionServiceTest.java
@@ -9,10 +9,11 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 
 import team.themoment.hellogsmv3.domain.member.entity.Member;
@@ -23,6 +24,7 @@ import team.themoment.hellogsmv3.domain.oneseo.entity.type.YesNo;
 import team.themoment.hellogsmv3.domain.oneseo.repository.OneseoRepository;
 import team.themoment.sdk.exception.ExpectedException;
 
+@ExtendWith(MockitoExtension.class)
 @DisplayName("ModifyEntranceIntentionService 클래스의")
 class ModifyEntranceIntentionServiceTest {
     @Mock
@@ -32,11 +34,6 @@ class ModifyEntranceIntentionServiceTest {
 
     @InjectMocks
     private ModifyEntranceIntentionService modifyEntranceIntentionService;
-
-    @BeforeEach
-    void setUp() {
-        MockitoAnnotations.openMocks(this);
-    }
 
     @Nested
     @DisplayName("execute 메서드는")

--- a/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyInterviewScoreServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyInterviewScoreServiceTest.java
@@ -18,7 +18,6 @@ import org.mockito.MockitoAnnotations;
 import org.springframework.http.HttpStatus;
 
 import team.themoment.hellogsmv3.domain.member.entity.Member;
-import team.themoment.hellogsmv3.domain.member.service.MemberService;
 import team.themoment.hellogsmv3.domain.oneseo.dto.request.InterviewScoreReqDto;
 import team.themoment.hellogsmv3.domain.oneseo.entity.EntranceTestResult;
 import team.themoment.hellogsmv3.domain.oneseo.entity.Oneseo;
@@ -26,10 +25,7 @@ import team.themoment.hellogsmv3.domain.oneseo.repository.EntranceTestResultRepo
 import team.themoment.sdk.exception.ExpectedException;
 
 @DisplayName("ModifyInterviewScoreService 클래스의")
-public class ModifyInterviewScoreServiceTest {
-
-    @Mock
-    private MemberService memberService;
+class ModifyInterviewScoreServiceTest {
     @Mock
     private OneseoService oneseoService;
     @Mock
@@ -44,7 +40,7 @@ public class ModifyInterviewScoreServiceTest {
     }
 
     @Nested
-    @DisplayName("execute 메소드는")
+    @DisplayName("execute 메서드는")
     class Describe_execute {
 
         private final Long memberId = 1L;
@@ -69,7 +65,7 @@ public class ModifyInterviewScoreServiceTest {
             }
 
             @Test
-            @DisplayName("심층면접 점수를 저장한다.")
+            @DisplayName("심층면접 점수를 저장한다")
             void it_saves_interview_score() {
                 InterviewScoreReqDto interviewScoreReqDto = new InterviewScoreReqDto(updatedInterviewScore);
                 modifyInterviewScoreService.execute(memberId, interviewScoreReqDto);

--- a/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyInterviewScoreServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyInterviewScoreServiceTest.java
@@ -11,10 +11,11 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 
 import team.themoment.hellogsmv3.domain.member.entity.Member;
@@ -24,6 +25,7 @@ import team.themoment.hellogsmv3.domain.oneseo.entity.Oneseo;
 import team.themoment.hellogsmv3.domain.oneseo.repository.EntranceTestResultRepository;
 import team.themoment.sdk.exception.ExpectedException;
 
+@ExtendWith(MockitoExtension.class)
 @DisplayName("ModifyInterviewScoreService 클래스의")
 class ModifyInterviewScoreServiceTest {
     @Mock
@@ -33,11 +35,6 @@ class ModifyInterviewScoreServiceTest {
 
     @InjectMocks
     private ModifyInterviewScoreService modifyInterviewScoreService;
-
-    @BeforeEach
-    void setUp() {
-        MockitoAnnotations.openMocks(this);
-    }
 
     @Nested
     @DisplayName("execute 메서드는")

--- a/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyOneseoByApplicantServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyOneseoByApplicantServiceTest.java
@@ -10,9 +10,10 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 
 import team.themoment.hellogsmv3.domain.oneseo.dto.request.OneseoReqDto;
@@ -20,6 +21,7 @@ import team.themoment.hellogsmv3.domain.oneseo.entity.Oneseo;
 import team.themoment.hellogsmv3.domain.oneseo.entity.type.OneseoEditStatus;
 import team.themoment.sdk.exception.ExpectedException;
 
+@ExtendWith(MockitoExtension.class)
 @DisplayName("ModifyOneseoByApplicantService 클래스의")
 class ModifyOneseoByApplicantServiceTest {
 
@@ -31,11 +33,6 @@ class ModifyOneseoByApplicantServiceTest {
 
     @InjectMocks
     private ModifyOneseoByApplicantService service;
-
-    @BeforeEach
-    void setUp() {
-        MockitoAnnotations.openMocks(this);
-    }
 
     @Nested
     @DisplayName("execute 메서드는")

--- a/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyOneseoServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyOneseoServiceTest.java
@@ -3,6 +3,7 @@ package team.themoment.hellogsmv3.domain.oneseo.service;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willThrow;
 import static org.mockito.Mockito.*;
 import static team.themoment.hellogsmv3.domain.oneseo.entity.type.GraduationType.CANDIDATE;
 import static team.themoment.hellogsmv3.domain.oneseo.entity.type.Major.*;
@@ -21,7 +22,6 @@ import org.mockito.*;
 import org.springframework.http.HttpStatus;
 
 import team.themoment.hellogsmv3.domain.member.entity.Member;
-import team.themoment.hellogsmv3.domain.member.service.MemberService;
 import team.themoment.hellogsmv3.domain.oneseo.dto.request.MiddleSchoolAchievementReqDto;
 import team.themoment.hellogsmv3.domain.oneseo.dto.request.OneseoReqDto;
 import team.themoment.hellogsmv3.domain.oneseo.dto.response.CalculatedScoreResDto;
@@ -58,8 +58,6 @@ class ModifyOneseoServiceTest {
     @Mock
     private OneseoService oneseoService;
     @Mock
-    private MemberService memberService;
-    @Mock
     private LambdaScoreCalculatorClient lambdaScoreCalculatorClient;
 
     @InjectMocks
@@ -78,7 +76,7 @@ class ModifyOneseoServiceTest {
 
         List<Integer> achievement = Arrays.asList(5, 5, 5, 5, 5, 5, 5, 5, 5);
         List<String> generalSubjects = Arrays.asList("국어", "도덕", "사회", "역사", "수학", "과학", "기술가정", "영어");
-        List<String> newSubjects = Arrays.asList("프로그래밍");
+        List<String> newSubjects = List.of("프로그래밍");
         List<Integer> artsPhysicalAchievement = Arrays.asList(5, 5, 5, 5, 5, 5, 5, 5, 5);
         List<String> artsPhysicalSubjects = Arrays.asList("체육", "미술", "음악");
         List<Integer> absentDays = Arrays.asList(0, 0, 0);
@@ -220,10 +218,9 @@ class ModifyOneseoServiceTest {
             }
 
             @Test
-            @DisplayName("전형이 변경되었다면 히스토리를 남긴다.")
+            @DisplayName("전형이 변경되었다면 히스토리를 남긴다")
             void it_change_screening_entity_save() {
                 Screening beforeScreening = SPECIAL;
-                Screening afterScreening = GENERAL;
                 Member existingMember = mock(Member.class);
                 Oneseo oneseo = Oneseo.builder().id(1L).member(existingMember).wantedScreening(beforeScreening)
                         .desiredMajors(desiredMajors)
@@ -252,7 +249,7 @@ class ModifyOneseoServiceTest {
                         .getValue();
 
                 assertEquals(beforeScreening, capturedScreeningChangeHistory.getBeforeScreening());
-                assertEquals(afterScreening, capturedScreeningChangeHistory.getAfterScreening());
+                assertEquals(GENERAL, capturedScreeningChangeHistory.getAfterScreening());
             }
         }
 
@@ -262,8 +259,9 @@ class ModifyOneseoServiceTest {
 
             @BeforeEach
             void setUp() {
-                doThrow(new ExpectedException("해당 지원자의 원서를 찾을 수 없습니다. member ID: " + memberId, HttpStatus.BAD_REQUEST))
-                        .when(oneseoService).findWithMemberByMemberIdOrThrow(memberId);
+                willThrow(
+                        new ExpectedException("해당 지원자의 원서를 찾을 수 없습니다. member ID: " + memberId, HttpStatus.BAD_REQUEST))
+                        .given(oneseoService).findWithMemberByMemberIdOrThrow(memberId);
             }
 
             @Test
@@ -282,8 +280,9 @@ class ModifyOneseoServiceTest {
 
             @BeforeEach
             void setUp() {
-                doThrow(new ExpectedException("해당 지원자의 원서를 찾을 수 없습니다. member ID: " + memberId, HttpStatus.BAD_REQUEST))
-                        .when(oneseoService).findWithMemberByMemberIdOrThrow(memberId);
+                willThrow(
+                        new ExpectedException("해당 지원자의 원서를 찾을 수 없습니다. member ID: " + memberId, HttpStatus.BAD_REQUEST))
+                        .given(oneseoService).findWithMemberByMemberIdOrThrow(memberId);
             }
 
             @Test

--- a/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyOneseoServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyOneseoServiceTest.java
@@ -18,7 +18,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.*;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 
 import team.themoment.hellogsmv3.domain.member.entity.Member;
@@ -40,6 +42,7 @@ import team.themoment.hellogsmv3.global.thirdParty.feign.client.dto.request.Lamb
 import team.themoment.hellogsmv3.global.thirdParty.feign.client.lambda.LambdaScoreCalculatorClient;
 import team.themoment.sdk.exception.ExpectedException;
 
+@ExtendWith(MockitoExtension.class)
 @DisplayName("ModifyOneseoService 클래스의")
 class ModifyOneseoServiceTest {
 
@@ -62,11 +65,6 @@ class ModifyOneseoServiceTest {
 
     @InjectMocks
     private ModifyOneseoService modifyOneseoService;
-
-    @BeforeEach
-    void setUp() {
-        MockitoAnnotations.openMocks(this);
-    }
 
     @Nested
     @DisplayName("execute 메서드는")

--- a/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyPersonalInfoServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyPersonalInfoServiceTest.java
@@ -11,7 +11,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.*;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 
 import team.themoment.hellogsmv3.domain.member.entity.Member;
@@ -24,6 +26,7 @@ import team.themoment.hellogsmv3.domain.oneseo.entity.type.YesNo;
 import team.themoment.hellogsmv3.domain.oneseo.repository.OneseoRepository;
 import team.themoment.sdk.exception.ExpectedException;
 
+@ExtendWith(MockitoExtension.class)
 @DisplayName("ModifyPersonalInfoService 클래스의")
 class ModifyPersonalInfoServiceTest {
 
@@ -35,11 +38,6 @@ class ModifyPersonalInfoServiceTest {
 
     @InjectMocks
     private ModifyPersonalInfoService modifyPersonalInfoService;
-
-    @BeforeEach
-    void setUp() {
-        MockitoAnnotations.openMocks(this);
-    }
 
     @Nested
     @DisplayName("execute 메서드는")

--- a/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyRealOneseoArrivedYnServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyRealOneseoArrivedYnServiceTest.java
@@ -9,9 +9,10 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 
 import team.themoment.hellogsmv3.domain.member.entity.Member;
@@ -23,6 +24,7 @@ import team.themoment.hellogsmv3.domain.oneseo.entity.type.YesNo;
 import team.themoment.hellogsmv3.domain.oneseo.repository.OneseoRepository;
 import team.themoment.sdk.exception.ExpectedException;
 
+@ExtendWith(MockitoExtension.class)
 @DisplayName("ModifyRealOneseoArrivedYnService 클래스의")
 class ModifyRealOneseoArrivedYnServiceTest {
 
@@ -34,11 +36,6 @@ class ModifyRealOneseoArrivedYnServiceTest {
 
     @InjectMocks
     private ModifyRealOneseoArrivedYnService modifyRealOneseoArrivedYnService;
-
-    @BeforeEach
-    void setUp() {
-        MockitoAnnotations.openMocks(this);
-    }
 
     @Nested
     @DisplayName("execute 메서드는")

--- a/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyRealOneseoArrivedYnServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyRealOneseoArrivedYnServiceTest.java
@@ -15,7 +15,6 @@ import org.mockito.MockitoAnnotations;
 import org.springframework.http.HttpStatus;
 
 import team.themoment.hellogsmv3.domain.member.entity.Member;
-import team.themoment.hellogsmv3.domain.member.service.MemberService;
 import team.themoment.hellogsmv3.domain.oneseo.dto.response.ArrivedStatusResDto;
 import team.themoment.hellogsmv3.domain.oneseo.entity.EntranceTestResult;
 import team.themoment.hellogsmv3.domain.oneseo.entity.Oneseo;
@@ -25,10 +24,7 @@ import team.themoment.hellogsmv3.domain.oneseo.repository.OneseoRepository;
 import team.themoment.sdk.exception.ExpectedException;
 
 @DisplayName("ModifyRealOneseoArrivedYnService 클래스의")
-public class ModifyRealOneseoArrivedYnServiceTest {
-
-    @Mock
-    private MemberService memberService;
+class ModifyRealOneseoArrivedYnServiceTest {
 
     @Mock
     private OneseoService oneseoService;
@@ -45,7 +41,7 @@ public class ModifyRealOneseoArrivedYnServiceTest {
     }
 
     @Nested
-    @DisplayName("execute 메소드는")
+    @DisplayName("execute 메서드는")
     class Describe_execute {
         private final Long memberId = 1L;
 
@@ -68,7 +64,7 @@ public class ModifyRealOneseoArrivedYnServiceTest {
             }
 
             @Test
-            @DisplayName("원서 도착 여부를 전환하고, 해당 정보를 반환한다.")
+            @DisplayName("원서 도착 여부를 전환하고, 해당 정보를 반환한다")
             void it_switch_and_returns_arrived_status() {
                 ArrivedStatusResDto result = modifyRealOneseoArrivedYnService.execute(memberId);
 

--- a/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/OneseoServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/OneseoServiceTest.java
@@ -17,9 +17,10 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 
 import team.themoment.hellogsmv3.domain.member.entity.Member;
@@ -32,6 +33,7 @@ import team.themoment.hellogsmv3.domain.oneseo.entity.type.GraduationType;
 import team.themoment.hellogsmv3.domain.oneseo.repository.OneseoRepository;
 import team.themoment.sdk.exception.ExpectedException;
 
+@ExtendWith(MockitoExtension.class)
 @DisplayName("OneseoService 클래스의")
 class OneseoServiceTest {
 
@@ -40,11 +42,6 @@ class OneseoServiceTest {
 
     @InjectMocks
     private OneseoService oneseoService;
-
-    @BeforeEach
-    void setUp() {
-        MockitoAnnotations.openMocks(this);
-    }
 
     @Nested
     @DisplayName("findWithMemberByMemberIdOrThrow 메서드는")

--- a/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/OneseoServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/OneseoServiceTest.java
@@ -33,7 +33,7 @@ import team.themoment.hellogsmv3.domain.oneseo.repository.OneseoRepository;
 import team.themoment.sdk.exception.ExpectedException;
 
 @DisplayName("OneseoService 클래스의")
-public class OneseoServiceTest {
+class OneseoServiceTest {
 
     @Mock
     private OneseoRepository oneseoRepository;
@@ -47,7 +47,7 @@ public class OneseoServiceTest {
     }
 
     @Nested
-    @DisplayName("findWithMemberByMemberIdOrThrow 메소드는")
+    @DisplayName("findWithMemberByMemberIdOrThrow 메서드는")
     class Describe_findWithMemberByMemberIdOrThrow {
 
         private final Long memberId = 1L;
@@ -65,7 +65,7 @@ public class OneseoServiceTest {
             }
 
             @Test
-            @DisplayName("Oneseo 객체를 반환한다.")
+            @DisplayName("Oneseo 객체를 반환한다")
             void it_returns_oneseo() {
                 Oneseo foundOneseo = oneseoService.findWithMemberByMemberIdOrThrow(memberId);
                 assertEquals(oneseo, foundOneseo);
@@ -83,7 +83,7 @@ public class OneseoServiceTest {
             }
 
             @Test
-            @DisplayName("ExpectedException을 던진다.")
+            @DisplayName("ExpectedException을 던진다")
             void it_throws_expected_exception_for_non_existing_member() {
                 ExpectedException exception = assertThrows(ExpectedException.class,
                         () -> oneseoService.findWithMemberByMemberIdOrThrow(memberId));
@@ -104,7 +104,7 @@ public class OneseoServiceTest {
             }
 
             @Test
-            @DisplayName("ExpectedException을 던진다.")
+            @DisplayName("ExpectedException을 던진다")
             void it_throws_expected_exception_for_non_existing_oneseo() {
                 ExpectedException exception = assertThrows(ExpectedException.class,
                         () -> oneseoService.findWithMemberByMemberIdOrThrow(memberId));
@@ -116,7 +116,7 @@ public class OneseoServiceTest {
     }
 
     @Nested
-    @DisplayName("calcAbsentDaysCount 메소드는")
+    @DisplayName("calcAbsentDaysCount 메서드는")
     class Describe_calcAbsentDaysCount {
 
         @Nested
@@ -127,7 +127,7 @@ public class OneseoServiceTest {
             List<Integer> attendanceDays = List.of(0, 0, 0, 1, 0, 1, 0, 2, 2);
 
             @Test
-            @DisplayName("환산일수를 반환한다.")
+            @DisplayName("환산일수를 반환한다")
             void it_returns_oneseo() {
                 Integer absentDaysCount = OneseoService.calcAbsentDaysCount(absentDays, attendanceDays);
                 assertEquals(5, absentDaysCount);
@@ -142,7 +142,7 @@ public class OneseoServiceTest {
             List<Integer> nullAttendanceDays = null;
 
             @Test
-            @DisplayName("null 값을 반환한다.")
+            @DisplayName("null 값을 반환한다")
             void it_returns_oneseo() {
                 Integer absentDaysCount = OneseoService.calcAbsentDaysCount(nullAbsentDays, nullAttendanceDays);
                 assertNull(absentDaysCount);
@@ -157,7 +157,7 @@ public class OneseoServiceTest {
             List<Integer> nullInAttendanceDays = Arrays.asList(0, 0, 0, 1, 0, 1, null, 2, 2);
 
             @Test
-            @DisplayName("예외를 던진다.")
+            @DisplayName("예외를 던진다")
             void it_returns_oneseo() {
                 ExpectedException exception = assertThrows(ExpectedException.class,
                         () -> OneseoService.calcAbsentDaysCount(nullInAbsentDays, nullInAttendanceDays));
@@ -169,7 +169,7 @@ public class OneseoServiceTest {
     }
 
     @Nested
-    @DisplayName("isValidMiddleSchoolInfo 메소드는")
+    @DisplayName("isValidMiddleSchoolInfo 메서드는")
     class Describe_isValidMiddleSchoolInfo {
 
         private final OneseoReqDto validCandidateReqDto = OneseoReqDto.builder().schoolName("금호중앙중학교")
@@ -187,7 +187,7 @@ public class OneseoServiceTest {
         class Context_with_valid_candidate {
 
             @Test
-            @DisplayName("예외를 던지지 않는다.")
+            @DisplayName("예외를 던지지 않는다")
             void it_does_not_throw_exception() {
                 OneseoService.isValidMiddleSchoolInfo(validCandidateReqDto);
             }
@@ -198,7 +198,7 @@ public class OneseoServiceTest {
         class Context_with_valid_ged {
 
             @Test
-            @DisplayName("예외를 던지지 않는다.")
+            @DisplayName("예외를 던지지 않는다")
             void it_does_not_throw_exception() {
                 OneseoService.isValidMiddleSchoolInfo(validGedReqDto);
             }
@@ -209,7 +209,7 @@ public class OneseoServiceTest {
         class Context_with_invalid_candidate {
 
             @Test
-            @DisplayName("ExpectedException을 던진다.")
+            @DisplayName("ExpectedException을 던진다")
             void it_throws_expected_exception() {
                 ExpectedException exception = assertThrows(ExpectedException.class,
                         () -> OneseoService.isValidMiddleSchoolInfo(invalidCandidateReqDto));
@@ -221,7 +221,7 @@ public class OneseoServiceTest {
     }
 
     @Nested
-    @DisplayName("assignSubmitCode 메소드는")
+    @DisplayName("assignSubmitCode 메서드는")
     class Describe_assignSubmitCode {
 
         private final int maxSubmitCodeNumber = 10;
@@ -239,7 +239,7 @@ public class OneseoServiceTest {
             }
 
             @Test
-            @DisplayName("A-N 번대의 접수번호가 생성된다.")
+            @DisplayName("A-N 번대의 접수번호가 생성된다")
             void it_returns_oneseo() {
                 oneseoService.assignSubmitCode(oneseo, null);
                 verify(oneseo).setOneseoSubmitCode("A-" + (maxSubmitCodeNumber + 1));
@@ -248,7 +248,7 @@ public class OneseoServiceTest {
     }
 
     @Nested
-    @DisplayName("buildCalcDtoWithFillEmpty 메소드는")
+    @DisplayName("buildCalcDtoWithFillEmpty 메서드는")
     class Describe_buildCalcDtoWithFillEmpty {
         private MiddleSchoolAchievementReqDto middleSchoolAchievementReqDto;
 
@@ -269,7 +269,7 @@ public class OneseoServiceTest {
             }
 
             @Test
-            @DisplayName("검정고시 평균 점수만 포함된 DTO를 반환한다.")
+            @DisplayName("검정고시 평균 점수만 포함된 DTO를 반환한다")
             void it_returns_dto_with_ged_avg_score() {
                 MiddleSchoolAchievementCalcDto resultDto = OneseoService
                         .buildCalcDtoWithFillEmpty(middleSchoolAchievementReqDto, graduationType);
@@ -295,7 +295,7 @@ public class OneseoServiceTest {
             }
 
             @Test
-            @DisplayName("3학년 2학기 성적을 3학년 1학기 성적으로 채운 DTO를 반환한다.")
+            @DisplayName("3학년 2학기 성적을 3학년 1학기 성적으로 채운 DTO를 반환한다")
             void it_fills_3_2_with_3_1() {
                 MiddleSchoolAchievementCalcDto resultDto = OneseoService
                         .buildCalcDtoWithFillEmpty(middleSchoolAchievementReqDto, graduationType);
@@ -320,7 +320,7 @@ public class OneseoServiceTest {
             }
 
             @Test
-            @DisplayName("3학년 1학기 성적을 3학년 2학기 성적으로 채운 DTO를 반환한다.")
+            @DisplayName("3학년 1학기 성적을 3학년 2학기 성적으로 채운 DTO를 반환한다")
             void it_fills_3_1_with_3_2() {
                 MiddleSchoolAchievementCalcDto resultDto = OneseoService
                         .buildCalcDtoWithFillEmpty(middleSchoolAchievementReqDto, graduationType);
@@ -345,7 +345,7 @@ public class OneseoServiceTest {
             }
 
             @Test
-            @DisplayName("2학년 1학기 성적을 2학년 2학기 성적으로 채운 DTO를 반환한다.")
+            @DisplayName("2학년 1학기 성적을 2학년 2학기 성적으로 채운 DTO를 반환한다")
             void it_fills_2_1_with_2_2() {
                 MiddleSchoolAchievementCalcDto resultDto = OneseoService
                         .buildCalcDtoWithFillEmpty(middleSchoolAchievementReqDto, graduationType);
@@ -370,7 +370,7 @@ public class OneseoServiceTest {
             }
 
             @Test
-            @DisplayName("2학년 2학기 성적을 2학년 1학기 성적으로 채운 DTO를 반환한다.")
+            @DisplayName("2학년 2학기 성적을 2학년 1학기 성적으로 채운 DTO를 반환한다")
             void it_fills_2_2_with_2_1() {
                 MiddleSchoolAchievementCalcDto resultDto = OneseoService
                         .buildCalcDtoWithFillEmpty(middleSchoolAchievementReqDto, graduationType);
@@ -395,7 +395,7 @@ public class OneseoServiceTest {
             }
 
             @Test
-            @DisplayName("1학년 2학기 성적을 1학년 1학기 성적으로 채운 DTO를 반환한다.")
+            @DisplayName("1학년 2학기 성적을 1학년 1학기 성적으로 채운 DTO를 반환한다")
             void it_fills_1_2_with_1_1() {
                 MiddleSchoolAchievementCalcDto resultDto = OneseoService
                         .buildCalcDtoWithFillEmpty(middleSchoolAchievementReqDto, graduationType);
@@ -421,7 +421,7 @@ public class OneseoServiceTest {
             }
 
             @Test
-            @DisplayName("1학년 2학기 성적을 2학년 2학기 성적으로 채운 DTO를 반환한다.")
+            @DisplayName("1학년 2학기 성적을 2학년 2학기 성적으로 채운 DTO를 반환한다")
             void it_fills_1_2_with_2_2() {
                 MiddleSchoolAchievementCalcDto resultDto = OneseoService
                         .buildCalcDtoWithFillEmpty(middleSchoolAchievementReqDto, graduationType);
@@ -448,7 +448,7 @@ public class OneseoServiceTest {
             }
 
             @Test
-            @DisplayName("ExpectedException을 던진다.")
+            @DisplayName("ExpectedException을 던진다")
             void it_throws_expected_exception() {
                 ExpectedException exception = assertThrows(ExpectedException.class,
                         () -> OneseoService.buildCalcDtoWithFillEmpty(middleSchoolAchievementReqDto, graduationType));
@@ -472,7 +472,7 @@ public class OneseoServiceTest {
             }
 
             @Test
-            @DisplayName("ExpectedException을 던진다.")
+            @DisplayName("ExpectedException을 던진다")
             void it_throws_expected_exception() {
                 ExpectedException exception = assertThrows(ExpectedException.class,
                         () -> OneseoService.buildCalcDtoWithFillEmpty(middleSchoolAchievementReqDto, graduationType));
@@ -496,7 +496,7 @@ public class OneseoServiceTest {
             }
 
             @Test
-            @DisplayName("ExpectedException을 던진다.")
+            @DisplayName("ExpectedException을 던진다")
             void it_throws_expected_exception() {
                 ExpectedException exception = assertThrows(ExpectedException.class,
                         () -> OneseoService.buildCalcDtoWithFillEmpty(middleSchoolAchievementReqDto, graduationType));

--- a/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/OneseoTempStorageServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/OneseoTempStorageServiceTest.java
@@ -13,9 +13,10 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 
 import team.themoment.hellogsmv3.domain.member.entity.Member;
@@ -34,6 +35,7 @@ import team.themoment.hellogsmv3.global.thirdParty.feign.client.dto.request.Lamb
 import team.themoment.hellogsmv3.global.thirdParty.feign.client.lambda.LambdaScoreCalculatorClient;
 import team.themoment.sdk.exception.ExpectedException;
 
+@ExtendWith(MockitoExtension.class)
 @DisplayName("OneseoTempStorageService 클래스의")
 class OneseoTempStorageServiceTest {
 
@@ -45,11 +47,6 @@ class OneseoTempStorageServiceTest {
     private LambdaScoreCalculatorClient lambdaScoreCalculatorClient;
     @InjectMocks
     private OneseoTempStorageService oneseoTempStorageService;
-
-    @BeforeEach
-    void setUp() {
-        MockitoAnnotations.openMocks(this);
-    }
 
     @Nested
     @DisplayName("execute 메서드는")

--- a/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/OneseoTempStorageServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/OneseoTempStorageServiceTest.java
@@ -35,7 +35,7 @@ import team.themoment.hellogsmv3.global.thirdParty.feign.client.lambda.LambdaSco
 import team.themoment.sdk.exception.ExpectedException;
 
 @DisplayName("OneseoTempStorageService 클래스의")
-public class OneseoTempStorageServiceTest {
+class OneseoTempStorageServiceTest {
 
     @Mock
     private MemberService memberService;
@@ -52,7 +52,7 @@ public class OneseoTempStorageServiceTest {
     }
 
     @Nested
-    @DisplayName("execute 메소드는")
+    @DisplayName("execute 메서드는")
     class Describe_execute {
 
         private final Long memberId = 1L;
@@ -91,7 +91,7 @@ public class OneseoTempStorageServiceTest {
 
             @Nested
             @DisplayName("회원이 원서를 제출하지 않았다면")
-            class Oneseo_not_exist {
+            class Context_oneseo_not_exist {
                 private final CalculatedScoreResDto calculatedScoreResDto = CalculatedScoreResDto.builder()
                         .generalSubjectsScore(new BigDecimal("80.000"))
                         .artsPhysicalSubjectsScore(new BigDecimal("10.000")).attendanceScore(new BigDecimal("5.000"))
@@ -105,7 +105,7 @@ public class OneseoTempStorageServiceTest {
                 }
 
                 @Test
-                @DisplayName("FoundOneseoResDto를 반환한다.")
+                @DisplayName("FoundOneseoResDto를 반환한다")
                 void it_returns_found_oneseo_res_dto() {
                     FoundOneseoResDto result = oneseoTempStorageService.execute(reqDto, step, memberId);
                     assertDto(result);
@@ -170,7 +170,7 @@ public class OneseoTempStorageServiceTest {
 
             @Nested
             @DisplayName("회원이 원서를 제출했고 수정 권한이 없다면")
-            class Oneseo_exist_without_edit_permission {
+            class Context_oneseo_exist_without_edit_permission {
                 @BeforeEach
                 void setUp() {
                     Oneseo oneseo = Oneseo.builder().member(member).oneseoEditStatus(OneseoEditStatus.NONE).build();
@@ -178,7 +178,7 @@ public class OneseoTempStorageServiceTest {
                 }
 
                 @Test
-                @DisplayName("ExpectedException을 던진다.")
+                @DisplayName("ExpectedException을 던진다")
                 void it_throws_expected_exception() {
                     ExpectedException exception = assertThrows(ExpectedException.class,
                             () -> oneseoTempStorageService.execute(reqDto, step, memberId));
@@ -190,7 +190,7 @@ public class OneseoTempStorageServiceTest {
 
             @Nested
             @DisplayName("회원이 원서를 제출했고 수정 권한이 APPROVED라면")
-            class Oneseo_exist_with_approved_edit_permission {
+            class Context_oneseo_exist_with_approved_edit_permission {
                 private final CalculatedScoreResDto calculatedScoreResDto = CalculatedScoreResDto.builder()
                         .generalSubjectsScore(new BigDecimal("80.000"))
                         .artsPhysicalSubjectsScore(new BigDecimal("10.000")).attendanceScore(new BigDecimal("5.000"))
@@ -205,7 +205,7 @@ public class OneseoTempStorageServiceTest {
                 }
 
                 @Test
-                @DisplayName("FoundOneseoResDto를 반환한다.")
+                @DisplayName("FoundOneseoResDto를 반환한다")
                 void it_returns_found_oneseo_res_dto() {
                     FoundOneseoResDto result = oneseoTempStorageService.execute(reqDto, step, memberId);
                     assertNotNull(result);
@@ -231,7 +231,7 @@ public class OneseoTempStorageServiceTest {
             }
 
             @Test
-            @DisplayName("ExpectedException을 던진다.")
+            @DisplayName("ExpectedException을 던진다")
             void it_throws_expected_exception() {
                 ExpectedException exception = assertThrows(ExpectedException.class,
                         () -> oneseoTempStorageService.execute(reqDto, step, memberId));

--- a/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/QueryAdmissionTicketsServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/QueryAdmissionTicketsServiceTest.java
@@ -19,7 +19,7 @@ import team.themoment.hellogsmv3.domain.oneseo.dto.response.AdmissionTicketsResD
 import team.themoment.hellogsmv3.domain.oneseo.repository.custom.CustomOneseoRepository;
 
 @DisplayName("QueryAdmissionTicketsService 클래스의")
-public class QueryAdmissionTicketsServiceTest {
+class QueryAdmissionTicketsServiceTest {
 
     @Mock
     private CustomOneseoRepository customOneseoRepository;
@@ -33,7 +33,7 @@ public class QueryAdmissionTicketsServiceTest {
     }
 
     @Nested
-    @DisplayName("execute 메소드는")
+    @DisplayName("execute 메서드는")
     class Describe_execute {
         AdmissionTicketsResDto firstadmissionTicketsResDto = AdmissionTicketsResDto.builder().memberName("홍길동")
                 .memberBirth(LocalDate.parse("2024-07-28")).profileImg("profileImg.com").schoolName("광주소프트웨어마이스터고등학교")
@@ -47,12 +47,12 @@ public class QueryAdmissionTicketsServiceTest {
                 secontadmissionTicketsResDto);
 
         @BeforeEach
-        void setup() {
+        void setUp() {
             given(customOneseoRepository.findAdmissionTickets()).willReturn(expectedTickets);
         }
 
         @Test
-        @DisplayName("수험표 리스트를 반환한다.")
+        @DisplayName("수험표 리스트를 반환한다")
         void it_return_admission_tickets() {
             List<AdmissionTicketsResDto> result = queryAdmissionTicketsService.execute();
 

--- a/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/QueryAdmissionTicketsServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/QueryAdmissionTicketsServiceTest.java
@@ -11,13 +11,15 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import team.themoment.hellogsmv3.domain.oneseo.dto.response.AdmissionTicketsResDto;
 import team.themoment.hellogsmv3.domain.oneseo.repository.custom.CustomOneseoRepository;
 
+@ExtendWith(MockitoExtension.class)
 @DisplayName("QueryAdmissionTicketsService 클래스의")
 class QueryAdmissionTicketsServiceTest {
 
@@ -26,11 +28,6 @@ class QueryAdmissionTicketsServiceTest {
 
     @InjectMocks
     private QueryAdmissionTicketsService queryAdmissionTicketsService;
-
-    @BeforeEach
-    void setUp() {
-        MockitoAnnotations.openMocks(this);
-    }
 
     @Nested
     @DisplayName("execute 메서드는")

--- a/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/QueryOneseoByIdServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/QueryOneseoByIdServiceTest.java
@@ -4,7 +4,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.when;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
@@ -22,7 +21,6 @@ import org.springframework.http.HttpStatus;
 
 import team.themoment.hellogsmv3.domain.member.entity.Member;
 import team.themoment.hellogsmv3.domain.member.entity.type.Sex;
-import team.themoment.hellogsmv3.domain.member.service.MemberService;
 import team.themoment.hellogsmv3.domain.oneseo.dto.response.*;
 import team.themoment.hellogsmv3.domain.oneseo.entity.*;
 import team.themoment.hellogsmv3.domain.oneseo.entity.type.DesiredMajors;
@@ -40,9 +38,6 @@ class QueryOneseoByIdServiceTest {
     private OneseoService oneseoService;
 
     @Mock
-    private MemberService memberService;
-
-    @Mock
     private OneseoPrivacyDetailRepository oneseoPrivacyDetailRepository;
 
     @Mock
@@ -57,7 +52,7 @@ class QueryOneseoByIdServiceTest {
     }
 
     @Nested
-    @DisplayName("execute 메소드는")
+    @DisplayName("execute 메서드는")
     class Describe_execute {
 
         private final Long memberId = 1L;
@@ -151,7 +146,7 @@ class QueryOneseoByIdServiceTest {
             void setUp_it_throws_expected_exception() {
                 member = buildMember(memberId);
 
-                when(oneseoService.findWithMemberByMemberIdOrThrow(memberId)).thenThrow(
+                given(oneseoService.findWithMemberByMemberIdOrThrow(memberId)).willThrow(
                         new ExpectedException("원서를 찾을 수 없습니다. member ID: " + memberId, HttpStatus.NOT_FOUND));
             }
 
@@ -160,9 +155,8 @@ class QueryOneseoByIdServiceTest {
             void it_throws_expected_exception() {
                 setUp_it_throws_expected_exception();
 
-                ExpectedException exception = assertThrows(ExpectedException.class, () -> {
-                    queryOneseoByIdService.execute(memberId);
-                });
+                ExpectedException exception = assertThrows(ExpectedException.class,
+                        () -> queryOneseoByIdService.execute(memberId));
 
                 assertEquals("원서를 찾을 수 없습니다. member ID: " + memberId, exception.getMessage());
                 assertEquals(HttpStatus.NOT_FOUND, exception.getStatusCode());
@@ -175,16 +169,15 @@ class QueryOneseoByIdServiceTest {
 
             @BeforeEach
             void setUp() {
-                when(oneseoService.findWithMemberByMemberIdOrThrow(memberId)).thenThrow(
+                given(oneseoService.findWithMemberByMemberIdOrThrow(memberId)).willThrow(
                         new ExpectedException("존재하지 않는 지원자입니다. member ID: " + memberId, HttpStatus.NOT_FOUND));
             }
 
             @Test
             @DisplayName("ExpectedException을 던진다")
             void it_throws_expected_exception() {
-                ExpectedException exception = assertThrows(ExpectedException.class, () -> {
-                    queryOneseoByIdService.execute(memberId);
-                });
+                ExpectedException exception = assertThrows(ExpectedException.class,
+                        () -> queryOneseoByIdService.execute(memberId));
 
                 assertEquals("존재하지 않는 지원자입니다. member ID: " + memberId, exception.getMessage());
                 assertEquals(HttpStatus.NOT_FOUND, exception.getStatusCode());

--- a/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/QueryOneseoByIdServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/QueryOneseoByIdServiceTest.java
@@ -14,9 +14,10 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 
 import team.themoment.hellogsmv3.domain.member.entity.Member;
@@ -31,6 +32,7 @@ import team.themoment.hellogsmv3.domain.oneseo.repository.MiddleSchoolAchievemen
 import team.themoment.hellogsmv3.domain.oneseo.repository.OneseoPrivacyDetailRepository;
 import team.themoment.sdk.exception.ExpectedException;
 
+@ExtendWith(MockitoExtension.class)
 @DisplayName("QueryOneseoByIdService 클래스의")
 class QueryOneseoByIdServiceTest {
 
@@ -45,11 +47,6 @@ class QueryOneseoByIdServiceTest {
 
     @InjectMocks
     private QueryOneseoByIdService queryOneseoByIdService;
-
-    @BeforeEach
-    void setUp() {
-        MockitoAnnotations.openMocks(this);
-    }
 
     @Nested
     @DisplayName("execute 메서드는")

--- a/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/QueryOneseoEditabilityServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/QueryOneseoEditabilityServiceTest.java
@@ -9,9 +9,10 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import team.themoment.hellogsmv3.domain.oneseo.dto.internal.FoundMemberAndOneseoDto;
 import team.themoment.hellogsmv3.domain.oneseo.dto.response.OneseoEditabilityResDto;
@@ -20,6 +21,7 @@ import team.themoment.hellogsmv3.domain.oneseo.entity.type.OneseoEditStatus;
 import team.themoment.hellogsmv3.domain.oneseo.repository.EntranceTestResultRepository;
 import team.themoment.hellogsmv3.domain.oneseo.repository.OneseoRepository;
 
+@ExtendWith(MockitoExtension.class)
 @DisplayName("QueryOneseoEditabilityService 클래스의")
 class QueryOneseoEditabilityServiceTest {
 
@@ -31,11 +33,6 @@ class QueryOneseoEditabilityServiceTest {
 
     @InjectMocks
     private QueryOneseoEditabilityService queryOneseoEditabilityService;
-
-    @BeforeEach
-    void setUp() {
-        MockitoAnnotations.openMocks(this);
-    }
 
     @Nested
     @DisplayName("execute 메서드는")

--- a/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/QueryOneseoEditabilityServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/QueryOneseoEditabilityServiceTest.java
@@ -38,7 +38,7 @@ class QueryOneseoEditabilityServiceTest {
     }
 
     @Nested
-    @DisplayName("execute 메소드는")
+    @DisplayName("execute 메서드는")
     class Describe_execute {
 
         @Nested

--- a/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/RequestOneseoEditPermissionServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/RequestOneseoEditPermissionServiceTest.java
@@ -14,9 +14,10 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 
 import team.themoment.hellogsmv3.domain.oneseo.entity.EntranceTestResult;
@@ -25,6 +26,7 @@ import team.themoment.hellogsmv3.domain.oneseo.entity.type.OneseoEditStatus;
 import team.themoment.hellogsmv3.domain.oneseo.entity.type.YesNo;
 import team.themoment.sdk.exception.ExpectedException;
 
+@ExtendWith(MockitoExtension.class)
 @DisplayName("RequestOneseoEditPermissionService 클래스의")
 class RequestOneseoEditPermissionServiceTest {
 
@@ -35,7 +37,6 @@ class RequestOneseoEditPermissionServiceTest {
 
     @BeforeEach
     void setUp() {
-        MockitoAnnotations.openMocks(this);
         service = spy(new RequestOneseoEditPermissionService(oneseoService));
     }
 

--- a/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/SearchOneseoServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/SearchOneseoServiceTest.java
@@ -13,9 +13,10 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
@@ -34,6 +35,7 @@ import team.themoment.hellogsmv3.domain.oneseo.entity.type.ScreeningCategory;
 import team.themoment.hellogsmv3.domain.oneseo.entity.type.YesNo;
 import team.themoment.hellogsmv3.domain.oneseo.repository.OneseoRepository;
 
+@ExtendWith(MockitoExtension.class)
 @DisplayName("SearchOneseoService 클래스의")
 class SearchOneseoServiceTest {
 
@@ -42,11 +44,6 @@ class SearchOneseoServiceTest {
 
     @InjectMocks
     private SearchOneseoService searchOneseoService;
-
-    @BeforeEach
-    void setUp() {
-        MockitoAnnotations.openMocks(this);
-    }
 
     @Nested
     @DisplayName("execute 메서드는")

--- a/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/SearchOneseoServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/SearchOneseoServiceTest.java
@@ -49,7 +49,7 @@ class SearchOneseoServiceTest {
     }
 
     @Nested
-    @DisplayName("execute 메소드는")
+    @DisplayName("execute 메서드는")
     class Describe_execute {
 
         private final int page = 0;
@@ -130,7 +130,7 @@ class SearchOneseoServiceTest {
                 assertEquals(1, searchOneseoPageInfoDto.totalElements());
                 assertEquals(1, searchOneseoPageInfoDto.totalPages());
 
-                SearchOneseoResDto searchOneseoResDto = result.oneseos().get(0);
+                SearchOneseoResDto searchOneseoResDto = result.oneseos().getFirst();
                 assertEquals(member.getId(), searchOneseoResDto.memberId());
                 assertEquals(oneseo.getOneseoSubmitCode(), searchOneseoResDto.submitCode());
                 assertEquals(oneseo.getRealOneseoArrivedYn(), searchOneseoResDto.realOneseoArrivedYn());
@@ -155,16 +155,14 @@ class SearchOneseoServiceTest {
 
             private Member member;
             private Oneseo oneseo;
-            private OneseoPrivacyDetail oneseoPrivacyDetail;
-            private EntranceTestResult entranceTestResult;
 
             @BeforeEach
             void setUp() {
                 Pageable pageable = PageRequest.of(page, size);
                 member = buildMember();
                 oneseo = buildOneseo();
-                oneseoPrivacyDetail = buildOneseoPrivacyDetail();
-                entranceTestResult = buildEntranceTestResult();
+                OneseoPrivacyDetail oneseoPrivacyDetail = buildOneseoPrivacyDetail();
+                EntranceTestResult entranceTestResult = buildEntranceTestResult();
 
                 SearchOneseoResDto searchOneseoResDto = buildSearchOneseoDto(member,
                         oneseo,
@@ -193,8 +191,8 @@ class SearchOneseoServiceTest {
 
                 assertEquals(1, result.info().totalElements());
                 assertEquals(1, result.oneseos().size());
-                assertEquals(member.getId(), result.oneseos().get(0).memberId());
-                assertEquals(oneseo.getOneseoSubmitCode(), result.oneseos().get(0).submitCode());
+                assertEquals(member.getId(), result.oneseos().getFirst().memberId());
+                assertEquals(oneseo.getOneseoSubmitCode(), result.oneseos().getFirst().submitCode());
             }
         }
 
@@ -204,16 +202,14 @@ class SearchOneseoServiceTest {
 
             private Member member;
             private Oneseo oneseo;
-            private OneseoPrivacyDetail oneseoPrivacyDetail;
-            private EntranceTestResult entranceTestResult;
 
             @BeforeEach
             void setUp() {
                 Pageable pageable = PageRequest.of(page, size);
                 member = buildMember();
                 oneseo = buildOneseo();
-                oneseoPrivacyDetail = buildOneseoPrivacyDetail();
-                entranceTestResult = buildEntranceTestResult();
+                OneseoPrivacyDetail oneseoPrivacyDetail = buildOneseoPrivacyDetail();
+                EntranceTestResult entranceTestResult = buildEntranceTestResult();
 
                 SearchOneseoResDto searchOneseoResDto = buildSearchOneseoDto(member,
                         oneseo,
@@ -242,8 +238,8 @@ class SearchOneseoServiceTest {
 
                 assertEquals(1, result.info().totalElements());
                 assertEquals(1, result.oneseos().size());
-                assertEquals(member.getId(), result.oneseos().get(0).memberId());
-                assertEquals(oneseo.getOneseoSubmitCode(), result.oneseos().get(0).submitCode());
+                assertEquals(member.getId(), result.oneseos().getFirst().memberId());
+                assertEquals(oneseo.getOneseoSubmitCode(), result.oneseos().getFirst().submitCode());
             }
         }
 
@@ -253,16 +249,14 @@ class SearchOneseoServiceTest {
 
             private Member member;
             private Oneseo oneseo;
-            private OneseoPrivacyDetail oneseoPrivacyDetail;
-            private EntranceTestResult entranceTestResult;
 
             @BeforeEach
             void setUp() {
                 Pageable pageable = PageRequest.of(page, size);
                 member = buildMember();
                 oneseo = buildOneseo();
-                oneseoPrivacyDetail = buildOneseoPrivacyDetail();
-                entranceTestResult = buildEntranceTestResult();
+                OneseoPrivacyDetail oneseoPrivacyDetail = buildOneseoPrivacyDetail();
+                EntranceTestResult entranceTestResult = buildEntranceTestResult();
 
                 SearchOneseoResDto searchOneseoResDto = buildSearchOneseoDto(member,
                         oneseo,
@@ -291,8 +285,8 @@ class SearchOneseoServiceTest {
 
                 assertEquals(1, result.info().totalElements());
                 assertEquals(1, result.oneseos().size());
-                assertEquals(member.getId(), result.oneseos().get(0).memberId());
-                assertEquals(oneseo.getOneseoSubmitCode(), result.oneseos().get(0).submitCode());
+                assertEquals(member.getId(), result.oneseos().getFirst().memberId());
+                assertEquals(oneseo.getOneseoSubmitCode(), result.oneseos().getFirst().submitCode());
             }
         }
     }

--- a/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/UploadExcelServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/UploadExcelServiceTest.java
@@ -237,8 +237,8 @@ class UploadExcelServiceTest {
         EntranceTestResult result = mock(EntranceTestResult.class);
         final BigDecimal[] compHolder = {competency};
         final BigDecimal[] interHolder = {interview};
-        given(result.getCompetencyEvaluationScore()).willAnswer(_ -> compHolder[0]);
-        given(result.getInterviewScore()).willAnswer(_ -> interHolder[0]);
+        given(result.getCompetencyEvaluationScore()).willAnswer(invocation -> compHolder[0]);
+        given(result.getInterviewScore()).willAnswer(invocation -> interHolder[0]);
         doAnswer(a -> {
             compHolder[0] = a.getArgument(0);
             return null;

--- a/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/UploadExcelServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/UploadExcelServiceTest.java
@@ -2,6 +2,7 @@ package team.themoment.hellogsmv3.domain.oneseo.service;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.*;
 
 import java.io.ByteArrayOutputStream;
@@ -51,7 +52,7 @@ class UploadExcelServiceTest {
     }
 
     @Nested
-    @DisplayName("execute 메소드는")
+    @DisplayName("execute 메서드는")
     class Describe_execute {
 
         @Nested
@@ -69,8 +70,8 @@ class UploadExcelServiceTest {
                 Map<String, EntranceTestResult> map = new HashMap<>();
                 map.put(exam1, r1);
                 map.put(exam2, r2);
-                when(oneseoRepository.findEntranceTestResultByExaminationNumbersIn(any())).thenReturn(map);
-                when(entranceTestResultRepository.saveAll(any())).thenAnswer(inv -> {
+                given(oneseoRepository.findEntranceTestResultByExaminationNumbersIn(any())).willReturn(map);
+                given(entranceTestResultRepository.saveAll(any())).willAnswer(inv -> {
                     Iterable<EntranceTestResult> it = inv.getArgument(0);
                     List<EntranceTestResult> list = new ArrayList<>();
                     it.forEach(list::add);
@@ -213,8 +214,8 @@ class UploadExcelServiceTest {
             @Test
             @DisplayName("ExpectedException을 던진다")
             void it_throws_not_found_exception() throws Exception {
-                when(oneseoRepository.findEntranceTestResultByExaminationNumbersIn(any()))
-                        .thenReturn(Collections.emptyMap());
+                given(oneseoRepository.findEntranceTestResultByExaminationNumbersIn(any()))
+                        .willReturn(Collections.emptyMap());
                 MultipartFile file = buildWorkbook(wb -> {
                     Sheet sheet = wb.createSheet();
                     Row header = sheet.createRow(0);
@@ -248,8 +249,8 @@ class UploadExcelServiceTest {
         EntranceTestResult result = mock(EntranceTestResult.class);
         final BigDecimal[] compHolder = {competency};
         final BigDecimal[] interHolder = {interview};
-        when(result.getCompetencyEvaluationScore()).thenAnswer(a -> compHolder[0]);
-        when(result.getInterviewScore()).thenAnswer(a -> interHolder[0]);
+        given(result.getCompetencyEvaluationScore()).willAnswer(a -> compHolder[0]);
+        given(result.getInterviewScore()).willAnswer(a -> interHolder[0]);
         doAnswer(a -> {
             compHolder[0] = a.getArgument(0);
             return null;
@@ -265,8 +266,8 @@ class UploadExcelServiceTest {
         EntranceTestResult r = mockEntranceResult(BigDecimal.ZERO, BigDecimal.ZERO);
         Map<String, EntranceTestResult> map = new HashMap<>();
         map.put(exam, r);
-        when(oneseoRepository.findEntranceTestResultByExaminationNumbersIn(any())).thenReturn(map);
-        when(entranceTestResultRepository.saveAll(any())).thenAnswer(inv -> {
+        given(oneseoRepository.findEntranceTestResultByExaminationNumbersIn(any())).willReturn(map);
+        given(entranceTestResultRepository.saveAll(any())).willAnswer(inv -> {
             Iterable<EntranceTestResult> it = inv.getArgument(0);
             List<EntranceTestResult> list = new ArrayList<>();
             it.forEach(list::add);

--- a/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/UploadExcelServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/UploadExcelServiceTest.java
@@ -15,10 +15,11 @@ import org.apache.poi.ss.usermodel.Row;
 import org.apache.poi.ss.usermodel.Sheet;
 import org.apache.poi.xssf.usermodel.XSSFWorkbook;
 import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.web.multipart.MultipartFile;
@@ -28,6 +29,7 @@ import team.themoment.hellogsmv3.domain.oneseo.repository.EntranceTestResultRepo
 import team.themoment.hellogsmv3.domain.oneseo.repository.OneseoRepository;
 import team.themoment.sdk.exception.ExpectedException;
 
+@ExtendWith(MockitoExtension.class)
 @DisplayName("UploadExcelService 클래스의")
 class UploadExcelServiceTest {
 
@@ -38,18 +40,6 @@ class UploadExcelServiceTest {
 
     @InjectMocks
     private UploadExcelService uploadExcelService;
-
-    private AutoCloseable mocks;
-
-    @BeforeEach
-    void setUp() {
-        mocks = MockitoAnnotations.openMocks(this);
-    }
-
-    @AfterEach
-    void tearDown() throws Exception {
-        mocks.close();
-    }
 
     @Nested
     @DisplayName("execute 메서드는")
@@ -143,7 +133,6 @@ class UploadExcelServiceTest {
             @Test
             @DisplayName("ExpectedException을 던진다")
             void it_throws_out_of_range_exception() throws Exception {
-                mockFindEntranceResults("1001");
                 MultipartFile file = buildWorkbook(wb -> {
                     Sheet sheet = wb.createSheet();
                     Row header = sheet.createRow(0);
@@ -167,7 +156,6 @@ class UploadExcelServiceTest {
             @Test
             @DisplayName("ExpectedException을 던진다")
             void it_throws_number_format_exception() throws Exception {
-                mockFindEntranceResults("1001");
                 MultipartFile file = buildWorkbook(wb -> {
                     Sheet sheet = wb.createSheet();
                     Row header = sheet.createRow(0);
@@ -249,8 +237,8 @@ class UploadExcelServiceTest {
         EntranceTestResult result = mock(EntranceTestResult.class);
         final BigDecimal[] compHolder = {competency};
         final BigDecimal[] interHolder = {interview};
-        given(result.getCompetencyEvaluationScore()).willAnswer(a -> compHolder[0]);
-        given(result.getInterviewScore()).willAnswer(a -> interHolder[0]);
+        given(result.getCompetencyEvaluationScore()).willAnswer(_ -> compHolder[0]);
+        given(result.getInterviewScore()).willAnswer(_ -> interHolder[0]);
         doAnswer(a -> {
             compHolder[0] = a.getArgument(0);
             return null;
@@ -260,19 +248,6 @@ class UploadExcelServiceTest {
             return null;
         }).when(result).modifyInterviewScore(any(BigDecimal.class));
         return result;
-    }
-
-    private void mockFindEntranceResults(String exam) {
-        EntranceTestResult r = mockEntranceResult(BigDecimal.ZERO, BigDecimal.ZERO);
-        Map<String, EntranceTestResult> map = new HashMap<>();
-        map.put(exam, r);
-        given(oneseoRepository.findEntranceTestResultByExaminationNumbersIn(any())).willReturn(map);
-        given(entranceTestResultRepository.saveAll(any())).willAnswer(inv -> {
-            Iterable<EntranceTestResult> it = inv.getArgument(0);
-            List<EntranceTestResult> list = new ArrayList<>();
-            it.forEach(list::add);
-            return list;
-        });
     }
 
     @FunctionalInterface

--- a/src/test/java/team/themoment/hellogsmv3/domain/security/auth/service/OAuthAuthenticationServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/security/auth/service/OAuthAuthenticationServiceTest.java
@@ -11,10 +11,11 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContext;
@@ -35,6 +36,7 @@ import team.themoment.hellogsmv3.global.security.auth.service.OAuthAuthenticatio
 import team.themoment.hellogsmv3.global.security.auth.service.OAuthProviderFactory;
 import team.themoment.hellogsmv3.global.security.auth.service.provider.OAuthProvider;
 
+@ExtendWith(MockitoExtension.class)
 @DisplayName("OAuthAuthenticationService 클래스의")
 class OAuthAuthenticationServiceTest {
 
@@ -60,7 +62,6 @@ class OAuthAuthenticationServiceTest {
 
     @BeforeEach
     void setUp() {
-        MockitoAnnotations.openMocks(this);
         oAuthAuthenticationService = new OAuthAuthenticationService(oAuthProviderFactory, memberRepository);
         ReflectionTestUtils.setField(oAuthAuthenticationService, "sessionTimeout", Duration.ofSeconds(10800));
     }
@@ -230,8 +231,6 @@ class OAuthAuthenticationServiceTest {
 
                 given(session.getAttribute(HttpSessionSecurityContextRepository.SPRING_SECURITY_CONTEXT_KEY))
                         .willThrow(new IllegalStateException("Session invalidated"));
-                given(session.getCreationTime()).willThrow(new IllegalStateException("Session invalidated"));
-                given(session.getLastAccessedTime()).willThrow(new IllegalStateException("Session invalidated"));
 
                 given(request.getSession(true)).willReturn(newSession);
             }

--- a/src/test/java/team/themoment/hellogsmv3/domain/security/auth/service/OAuthAuthenticationServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/security/auth/service/OAuthAuthenticationServiceTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.BDDMockito.*;
 
 import java.time.Duration;
+import java.util.Objects;
 import java.util.Optional;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -65,7 +66,7 @@ class OAuthAuthenticationServiceTest {
     }
 
     @Nested
-    @DisplayName("execute 메소드는")
+    @DisplayName("execute 메서드는")
     class Describe_execute {
 
         @Nested
@@ -78,15 +79,12 @@ class OAuthAuthenticationServiceTest {
             private final AuthReferrerType authReferrerType = AuthReferrerType.GOOGLE;
             private final Long memberId = 1L;
 
-            private Member existingMember;
-            private UserAuthInfo userAuthInfo;
-
             @BeforeEach
             void setUp() {
-                existingMember = Member.builder().id(memberId).email(email).role(Role.APPLICANT)
+                Member existingMember = Member.builder().id(memberId).email(email).role(Role.APPLICANT)
                         .authReferrerType(authReferrerType).build();
 
-                userAuthInfo = new UserAuthInfo(email, provider, authReferrerType);
+                UserAuthInfo userAuthInfo = new UserAuthInfo(email, provider, authReferrerType);
 
                 given(oAuthProviderFactory.getProvider(provider)).willReturn(oAuthProvider);
                 given(oAuthProvider.authenticate(code)).willReturn(userAuthInfo);
@@ -127,7 +125,7 @@ class OAuthAuthenticationServiceTest {
                     assertTrue(oAuthToken.getAuthorities().contains(new SimpleGrantedAuthority(Role.APPLICANT.name())));
 
                     DefaultOAuth2User oAuth2User = (DefaultOAuth2User) oAuthToken.getPrincipal();
-                    assertEquals(memberId, oAuth2User.getAttribute("id"));
+                    assertEquals(memberId, Objects.requireNonNull(oAuth2User).getAttribute("id"));
                     assertEquals(Role.APPLICANT, oAuth2User.getAttribute("role"));
                     assertEquals(provider, oAuth2User.getAttribute("provider"));
                     assertEquals(email, oAuth2User.getAttribute("email"));
@@ -149,17 +147,14 @@ class OAuthAuthenticationServiceTest {
             private final String code = "auth_code_123";
             private final String email = "s24059@gsm.hs.kr";
             private final AuthReferrerType authReferrerType = AuthReferrerType.GOOGLE;
-            private final Long newMemberId = 2L;
-
-            private Member newMember;
-            private UserAuthInfo userAuthInfo;
 
             @BeforeEach
             void setUp() {
-                newMember = Member.builder().id(newMemberId).email(email).role(Role.UNAUTHENTICATED)
+                Long newMemberId = 2L;
+                Member newMember = Member.builder().id(newMemberId).email(email).role(Role.UNAUTHENTICATED)
                         .authReferrerType(authReferrerType).build();
 
-                userAuthInfo = new UserAuthInfo(email, provider, authReferrerType);
+                UserAuthInfo userAuthInfo = new UserAuthInfo(email, provider, authReferrerType);
 
                 given(oAuthProviderFactory.getProvider(provider)).willReturn(oAuthProvider);
                 given(oAuthProvider.authenticate(code)).willReturn(userAuthInfo);
@@ -214,19 +209,17 @@ class OAuthAuthenticationServiceTest {
 
             private final String provider = "google";
             private final String code = "auth_code_123";
-            private final String email = "s23020@gsm.hs.kr";
             private final AuthReferrerType authReferrerType = AuthReferrerType.GOOGLE;
 
-            private Member existingMember;
-            private UserAuthInfo userAuthInfo;
             private HttpSession newSession;
 
             @BeforeEach
             void setUp() {
-                existingMember = Member.builder().id(1L).email(email).role(Role.APPLICANT)
+                String email = "s23020@gsm.hs.kr";
+                Member existingMember = Member.builder().id(1L).email(email).role(Role.APPLICANT)
                         .authReferrerType(authReferrerType).build();
 
-                userAuthInfo = new UserAuthInfo(email, provider, authReferrerType);
+                UserAuthInfo userAuthInfo = new UserAuthInfo(email, provider, authReferrerType);
                 newSession = mock(HttpSession.class);
 
                 given(oAuthProviderFactory.getProvider(provider)).willReturn(oAuthProvider);
@@ -272,19 +265,17 @@ class OAuthAuthenticationServiceTest {
 
             private final String provider = "google";
             private final String code = "auth_code_123";
-            private final String email = "s24059@gsm.hs.kr";
             private final AuthReferrerType authReferrerType = AuthReferrerType.GOOGLE;
 
-            private Member existingMember;
-            private UserAuthInfo userAuthInfo;
             private HttpSession newSession;
 
             @BeforeEach
             void setUp() {
-                existingMember = Member.builder().id(1L).email(email).role(Role.APPLICANT)
+                String email = "s24059@gsm.hs.kr";
+                Member existingMember = Member.builder().id(1L).email(email).role(Role.APPLICANT)
                         .authReferrerType(authReferrerType).build();
 
-                userAuthInfo = new UserAuthInfo(email, provider, authReferrerType);
+                UserAuthInfo userAuthInfo = new UserAuthInfo(email, provider, authReferrerType);
                 newSession = mock(HttpSession.class);
 
                 given(oAuthProviderFactory.getProvider(provider)).willReturn(oAuthProvider);
@@ -322,18 +313,15 @@ class OAuthAuthenticationServiceTest {
 
             private final String provider = "google";
             private final String code = "auth_code_123";
-            private final String email = "s23009@gsm.hs.kr";
             private final AuthReferrerType authReferrerType = AuthReferrerType.GOOGLE;
-
-            private Member memberWithNullRole;
-            private UserAuthInfo userAuthInfo;
 
             @BeforeEach
             void setUp() {
-                memberWithNullRole = Member.builder().id(1L).email(email).role(null).authReferrerType(authReferrerType)
-                        .build();
+                String email = "s23009@gsm.hs.kr";
+                Member memberWithNullRole = Member.builder().id(1L).email(email).role(null)
+                        .authReferrerType(authReferrerType).build();
 
-                userAuthInfo = new UserAuthInfo(email, provider, authReferrerType);
+                UserAuthInfo userAuthInfo = new UserAuthInfo(email, provider, authReferrerType);
 
                 given(oAuthProviderFactory.getProvider(provider)).willReturn(oAuthProvider);
                 given(oAuthProvider.authenticate(code)).willReturn(userAuthInfo);

--- a/src/test/java/team/themoment/hellogsmv3/domain/thirdParty/service/UploadImageServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/thirdParty/service/UploadImageServiceTest.java
@@ -5,6 +5,7 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.*;
 
 import java.io.InputStream;
+import java.net.URI;
 import java.net.URL;
 
 import org.junit.jupiter.api.AfterEach;
@@ -28,7 +29,7 @@ import team.themoment.hellogsmv3.global.thirdParty.aws.s3.service.UploadImageSer
 import team.themoment.sdk.exception.ExpectedException;
 
 @DisplayName("UploadImageService 클래스의")
-public class UploadImageServiceTest {
+class UploadImageServiceTest {
 
     @Mock
     private S3Template s3Template;
@@ -49,7 +50,7 @@ public class UploadImageServiceTest {
         s3Environment = mock(S3Environment.class);
         uploadImageService = new UploadImageService(s3Template, s3Environment);
 
-        when(s3Environment.bucketName()).thenReturn("bucket-name");
+        given(s3Environment.bucketName()).willReturn("bucket-name");
     }
 
     @AfterEach
@@ -60,7 +61,7 @@ public class UploadImageServiceTest {
     }
 
     @Nested
-    @DisplayName("execute 메소드는")
+    @DisplayName("execute 메서드는")
     class Describe_execute {
         String s3Key = "some-key";
 
@@ -70,7 +71,7 @@ public class UploadImageServiceTest {
             MultipartFile emptyFile = new MockMultipartFile("file", "", "text/plain", new byte[0]);
 
             @Test
-            @DisplayName("ExpectedException을 던진다.")
+            @DisplayName("ExpectedException을 던진다")
             void it_throws_expected_exception() {
                 ExpectedException exception = assertThrows(ExpectedException.class,
                         () -> uploadImageService.execute(emptyFile));
@@ -86,7 +87,7 @@ public class UploadImageServiceTest {
             MultipartFile file = new MockMultipartFile("file", "test.txt", "text/plain", "data".getBytes());
 
             @Test
-            @DisplayName("ExpectedException을 던진다.")
+            @DisplayName("ExpectedException을 던진다")
             void it_throws_expected_exception() {
                 ExpectedException exception = assertThrows(ExpectedException.class,
                         () -> uploadImageService.execute(file));
@@ -104,15 +105,15 @@ public class UploadImageServiceTest {
 
             @BeforeEach
             void setUp() throws Exception {
-                URL mockUrl = new URL("https://bucket-name.s3.amazonaws.com/" + s3Key);
-                when(mockS3Resource.getURL()).thenReturn(mockUrl);
+                URL mockUrl = URI.create("https://bucket-name.s3.amazonaws.com/" + s3Key).toURL();
+                given(mockS3Resource.getURL()).willReturn(mockUrl);
 
                 given(s3Template.upload(anyString(), anyString(), any(InputStream.class), any(ObjectMetadata.class)))
                         .willReturn(mockS3Resource);
             }
 
             @Test
-            @DisplayName("S3에 업로드된 파일의 URL을 반환한다.")
+            @DisplayName("S3에 업로드된 파일의 URL을 반환한다")
             void it_returns_uploaded_file_url() {
                 UploadImageResDto result = uploadImageService.execute(file);
 
@@ -133,7 +134,7 @@ public class UploadImageServiceTest {
             }
 
             @Test
-            @DisplayName("RuntimeException을 던진다.")
+            @DisplayName("RuntimeException을 던진다")
             void it_throws_runtime_exception() {
                 assertThrows(RuntimeException.class, () -> uploadImageService.execute(file));
             }

--- a/src/test/java/team/themoment/hellogsmv3/domain/thirdParty/service/UploadImageServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/thirdParty/service/UploadImageServiceTest.java
@@ -8,14 +8,14 @@ import java.io.InputStream;
 import java.net.URI;
 import java.net.URL;
 
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.web.multipart.MultipartFile;
@@ -28,6 +28,7 @@ import team.themoment.hellogsmv3.global.thirdParty.aws.s3.dto.response.UploadIma
 import team.themoment.hellogsmv3.global.thirdParty.aws.s3.service.UploadImageService;
 import team.themoment.sdk.exception.ExpectedException;
 
+@ExtendWith(MockitoExtension.class)
 @DisplayName("UploadImageService 클래스의")
 class UploadImageServiceTest {
 
@@ -40,24 +41,9 @@ class UploadImageServiceTest {
     @InjectMocks
     private UploadImageService uploadImageService;
 
-    private AutoCloseable closeable;
-
     @BeforeEach
     void setUp() {
-        closeable = MockitoAnnotations.openMocks(this);
-
-        s3Template = mock(S3Template.class);
-        s3Environment = mock(S3Environment.class);
         uploadImageService = new UploadImageService(s3Template, s3Environment);
-
-        given(s3Environment.bucketName()).willReturn("bucket-name");
-    }
-
-    @AfterEach
-    void tearDown() throws Exception {
-        if (closeable != null) {
-            closeable.close();
-        }
     }
 
     @Nested
@@ -106,6 +92,7 @@ class UploadImageServiceTest {
             @BeforeEach
             void setUp() throws Exception {
                 URL mockUrl = URI.create("https://bucket-name.s3.amazonaws.com/" + s3Key).toURL();
+                given(s3Environment.bucketName()).willReturn("bucket-name");
                 given(mockS3Resource.getURL()).willReturn(mockUrl);
 
                 given(s3Template.upload(anyString(), anyString(), any(InputStream.class), any(ObjectMetadata.class)))
@@ -129,6 +116,7 @@ class UploadImageServiceTest {
 
             @BeforeEach
             void setUp() {
+                given(s3Environment.bucketName()).willReturn("bucket-name");
                 given(s3Template.upload(anyString(), anyString(), any(InputStream.class), any(ObjectMetadata.class)))
                         .willThrow(new RuntimeException("AWS S3 upload error"));
             }


### PR DESCRIPTION
## 개요

도메인 전반의 테스트 코드 스타일을 표준화하고, Mockito 초기화 방식 개선 및 의존성 정리를 통해 테스트 코드의 일관성을 확보했습니다.

## 본문

JUnit5 관례에 따라 테스트 클래스와 메서드의 접근 제어자를 최적화하고, MockitoExtension을 사용하여 목(Mock) 초기화 방식을 표준화했습니다. 또한 일부 테스트에서 누락된 의존성을 추가하고 람다 파라미터를 명시적으로 개선했습니다.

### 추가

- `QueryDateServiceTest`: 신규 날짜 조회 서비스 테스트 추가

### 변경

- `@ExtendWith(MockitoExtension.class)`를 사용하여 Mockito 초기화 방식 표준화
- `CreateOneseoServiceTest` 내 누락된 Mock 의존성 추가
- `UploadExcelServiceTest` 등에서 람다 파라미터 명칭 명시 (`_` -> `invocation`)
- 테스트 클래스 및 메서드의 `public` 제어자 제거 (JUnit5 권장 사항 준수)
- `@DisplayName` 내의 '메소드' 용어를 '메서드'로 통일