### PR TITLE
[global] disender webhook 설정 추가

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -118,6 +118,8 @@ management:
 discord-alarm:
   url: ${DISCORD_RELAY_SERVER_URL}
   api-key: ${DISCORD_RELAY_SERVER_API_KEY}
+disender:
+  webhook-url: ${DISENDER_WEBHOOK_URL:}
 lambda-score-calculator:
   url: ${SCORE_CALCULATOR_SERVICE_URL}
   api-key: ${SCORE_CALCULATOR_API_KEY}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -119,7 +119,7 @@ discord-alarm:
   url: ${DISCORD_RELAY_SERVER_URL}
   api-key: ${DISCORD_RELAY_SERVER_API_KEY}
 disender:
-  webhook-url: ${DISENDER_WEBHOOK_URL:}
+  webhook-url: ${DISENDER_WEBHOOK_URL}
 lambda-score-calculator:
   url: ${SCORE_CALCULATOR_SERVICE_URL}
   api-key: ${SCORE_CALCULATOR_API_KEY}


### PR DESCRIPTION
## 개요

애플리케이션 시작/종료 시 Discord 알림을 발송하는 disender SDK 사용을 위한 설정을 `application.yml`에 추가했습니다.

## 본문

disender starter는 `disender.webhook-url` 프로퍼티를 읽어 동작하며, 값이 비어있을 경우 자동 비활성화됩니다. 환경별로 webhook URL을 주입할 수 있도록 환경 변수 기반으로 설정하고, 로컬 환경에서 미설정으로 인한 오류가 발생하지 않도록 기본값을 빈 문자열로 지정했습니다.

### 추가

- `application.yml`에 `disender.webhook-url` 프로퍼티 추가 (`DISENDER_WEBHOOK_URL` 환경 변수 주입, 기본값 빈 문자열)