### PR TITLE
[global] CI/CD 워크플로 JDK 버전을 25로 변경

### DIFF
--- a/.github/workflows/hellogsm-prod-cd.yml
+++ b/.github/workflows/hellogsm-prod-cd.yml
@@ -14,10 +14,10 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v5
 
-      - name: Setup JDK 17
+      - name: Setup JDK 25
         uses: actions/setup-java@v5
         with:
-          java-version: '17'
+          java-version: '25'
           distribution: 'temurin'
 
       - name: Setup Gradle

--- a/.github/workflows/hellogsm-prod-ci.yml
+++ b/.github/workflows/hellogsm-prod-ci.yml
@@ -17,10 +17,10 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v5
 
-      - name: Setup JDK 17
+      - name: Setup JDK 25
         uses: actions/setup-java@v5
         with:
-          java-version: '17'
+          java-version: '25'
           distribution: 'temurin'
 
       - name: Setup Gradle

--- a/.github/workflows/hellogsm-stage-cd.yml
+++ b/.github/workflows/hellogsm-stage-cd.yml
@@ -13,10 +13,10 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v5
 
-      - name: Setup JDK 17
+      - name: Setup JDK 25
         uses: actions/setup-java@v5
         with:
-          java-version: '17'
+          java-version: '25'
           distribution: 'temurin'
 
       - name: Setup Gradle

--- a/.github/workflows/hellogsm-stage-ci.yml
+++ b/.github/workflows/hellogsm-stage-ci.yml
@@ -17,10 +17,10 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v5
 
-      - name: Setup JDK 17
+      - name: Setup JDK 25
         uses: actions/setup-java@v5
         with:
-          java-version: '17'
+          java-version: '25'
           distribution: 'temurin'
 
       - name: Setup Gradle


### PR DESCRIPTION
## 개요

CI/CD 워크플로에서 셋업하는 JDK 버전을 17에서 25로 변경했습니다.

## 본문

`build.gradle`은 `JavaLanguageVersion.of(25)` toolchain을 요구하지만, 기존 CI/CD 워크플로는 JDK 17만 셋업하고 있었습니다. 이로 인해 runner에서 Gradle이 Java 25 toolchain을 별도로 프로비저닝하려 시도하면서 `spotlessGroovyGradle` 단계에서 빌드가 정상적으로 진행되지 않는 문제가 있었습니다. 이를 해결하기 위해 4개 워크플로 모두 JDK 25로 통일합니다.

### 변경

- `hellogsm-stage-ci.yml`: Setup JDK 17 → Setup JDK 25
- `hellogsm-prod-ci.yml`: Setup JDK 17 → Setup JDK 25
- `hellogsm-stage-cd.yml`: Setup JDK 17 → Setup JDK 25
- `hellogsm-prod-cd.yml`: Setup JDK 17 → Setup JDK 25