### PR TITLE
[global] 쿠키 도메인을 환경 변수로 제어하도록 변경

### DIFF
--- a/src/main/java/team/themoment/hellogsmv3/global/security/SessionCookieValidationConfig.java
+++ b/src/main/java/team/themoment/hellogsmv3/global/security/SessionCookieValidationConfig.java
@@ -4,6 +4,7 @@ import java.util.Arrays;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.web.server.Cookie;
 import org.springframework.boot.web.servlet.ServletContextInitializer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -33,7 +34,7 @@ public class SessionCookieValidationConfig {
             .anyMatch(p -> p.equals("dev") || p.equals("prod"));
         if (!isDeployedEnv) return;
 
-        if ("none".equalsIgnoreCase(sameSite) && !secure) {
+        if (Cookie.SameSite.NONE == Cookie.SameSite.valueOf(sameSite.toUpperCase()) && !secure) {
             throw new IllegalStateException(
                 "SameSite=None 설정 시 Secure=true 가 필요합니다. COOKIE_SECURE 환경 변수를 true 로 설정하세요."
             );

--- a/src/main/java/team/themoment/hellogsmv3/global/security/SessionCookieValidationConfig.java
+++ b/src/main/java/team/themoment/hellogsmv3/global/security/SessionCookieValidationConfig.java
@@ -1,15 +1,23 @@
 package team.themoment.hellogsmv3.global.security;
 
+import java.util.Arrays;
+
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.web.server.Cookie;
 import org.springframework.boot.web.servlet.ServletContextInitializer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
 import org.springframework.util.StringUtils;
 
 import jakarta.annotation.PostConstruct;
 
 @Configuration
 public class SessionCookieValidationConfig {
+
+    @Autowired
+    private Environment environment;
 
     @Value("${COOKIE_DOMAIN:}")
     private String cookieDomain;
@@ -22,7 +30,12 @@ public class SessionCookieValidationConfig {
 
     @PostConstruct
     public void validate() {
-        if ("none".equalsIgnoreCase(sameSite) && !secure) {
+        boolean isDeployedEnv = Arrays.stream(environment.getActiveProfiles())
+            .anyMatch(p -> p.equals("dev") || p.equals("prod"));
+        if (!isDeployedEnv) return;
+
+        Cookie.SameSitePolicy sameSitePolicy = Cookie.SameSitePolicy.valueOf(sameSite.toUpperCase());
+        if (Cookie.SameSitePolicy.NONE == sameSitePolicy && !secure) {
             throw new IllegalStateException(
                 "SameSite=None 설정 시 Secure=true 가 필요합니다. COOKIE_SECURE 환경 변수를 true 로 설정하세요."
             );

--- a/src/main/java/team/themoment/hellogsmv3/global/security/SessionCookieValidationConfig.java
+++ b/src/main/java/team/themoment/hellogsmv3/global/security/SessionCookieValidationConfig.java
@@ -2,7 +2,6 @@ package team.themoment.hellogsmv3.global.security;
 
 import java.util.Arrays;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.web.server.Cookie;
 import org.springframework.boot.web.servlet.ServletContextInitializer;
@@ -12,12 +11,13 @@ import org.springframework.core.env.Environment;
 import org.springframework.util.StringUtils;
 
 import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
 
 @Configuration
+@RequiredArgsConstructor
 public class SessionCookieValidationConfig {
 
-    @Autowired
-    private Environment environment;
+    private final Environment environment;
 
     @Value("${COOKIE_DOMAIN:}")
     private String cookieDomain;

--- a/src/main/java/team/themoment/hellogsmv3/global/security/SessionCookieValidationConfig.java
+++ b/src/main/java/team/themoment/hellogsmv3/global/security/SessionCookieValidationConfig.java
@@ -1,0 +1,40 @@
+package team.themoment.hellogsmv3.global.security;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.web.servlet.ServletContextInitializer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.util.StringUtils;
+
+import jakarta.annotation.PostConstruct;
+
+@Configuration
+public class SessionCookieValidationConfig {
+
+    @Value("${COOKIE_DOMAIN:}")
+    private String cookieDomain;
+
+    @Value("${server.servlet.session.cookie.same-site:lax}")
+    private String sameSite;
+
+    @Value("${server.servlet.session.cookie.secure:false}")
+    private boolean secure;
+
+    @PostConstruct
+    public void validate() {
+        if ("none".equalsIgnoreCase(sameSite) && !secure) {
+            throw new IllegalStateException(
+                "SameSite=None 설정 시 Secure=true 가 필요합니다. COOKIE_SECURE 환경 변수를 true 로 설정하세요."
+            );
+        }
+    }
+
+    @Bean
+    public ServletContextInitializer sessionCookieDomainInitializer() {
+        return servletContext -> {
+            if (StringUtils.hasText(cookieDomain)) {
+                servletContext.getSessionCookieConfig().setDomain(cookieDomain);
+            }
+        };
+    }
+}

--- a/src/main/java/team/themoment/hellogsmv3/global/security/SessionCookieValidationConfig.java
+++ b/src/main/java/team/themoment/hellogsmv3/global/security/SessionCookieValidationConfig.java
@@ -4,7 +4,6 @@ import java.util.Arrays;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.web.server.Cookie;
 import org.springframework.boot.web.servlet.ServletContextInitializer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -34,8 +33,7 @@ public class SessionCookieValidationConfig {
             .anyMatch(p -> p.equals("dev") || p.equals("prod"));
         if (!isDeployedEnv) return;
 
-        Cookie.SameSitePolicy sameSitePolicy = Cookie.SameSitePolicy.valueOf(sameSite.toUpperCase());
-        if (Cookie.SameSitePolicy.NONE == sameSitePolicy && !secure) {
+        if ("none".equalsIgnoreCase(sameSite) && !secure) {
             throw new IllegalStateException(
                 "SameSite=None 설정 시 Secure=true 가 필요합니다. COOKIE_SECURE 환경 변수를 true 로 설정하세요."
             );

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -8,6 +8,9 @@ server:
         http-only: true
         path: /
         max-age: 10800
+        domain: ${COOKIE_DOMAIN:}
+        secure: ${COOKIE_SECURE:false}
+        same-site: ${COOKIE_SAME_SITE:lax}
 logging:
   config: classpath:logback-spring.xml
 spring:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -8,7 +8,6 @@ server:
         http-only: true
         path: /
         max-age: 10800
-        domain: ${COOKIE_DOMAIN:}
         secure: ${COOKIE_SECURE:false}
         same-site: ${COOKIE_SAME_SITE:lax}
 logging:


### PR DESCRIPTION
## 개요

세션 쿠키의 Domain 속성이 고정값으로 설정되어 로컬 환경에서 브라우저가 쿠키를 수신하지 못하는 문제를 해결합니다. COOKIE_DOMAIN, COOKIE_SECURE, COOKIE_SAME_SITE 환경 변수로 쿠키 속성을 환경별로 제어할 수 있도록 변경했습니다.

## 본문

OAuth 로그인 후 서버가 세션 쿠키를 응답할 때 Domain=hellogsm.kr이 고정되어 있어, 로컬(localhost) 환경에서는 브라우저가 해당 쿠키를 수신하지 못했습니다. Tomcat은 domain이 빈 문자열이면 Domain= 속성을 쿠키에 포함하지 않으므로, 환경 변수 미설정 시 브라우저가 요청 호스트에 쿠키를 귀속시킵니다.

### 변경

- pplication.yml 세션 쿠키 설정에 domain, secure, same-site 항목 추가
- 각 항목은 환경 변수로 주입 받으며, 미설정 시 로컬 개발에 적합한 기본값 적용

| 환경 변수 | 기본값 | 설명 |
|---|---|---|
| COOKIE_DOMAIN | 빈 문자열 | 로컬은 미설정, dev/prod은 .hellogsm.kr |
| COOKIE_SECURE | alse | prod은 	rue |
| COOKIE_SAME_SITE | lax | 필요 시 
one으로 변경 |

redirect_uri 검증 로직(OAuth 제공자 위임 방식)은 변경하지 않았습니다.