### PR TITLE
[global] CORS allowedOrigins 설정 방식 변경 및 allowed-origins 환경변수화

### DIFF
--- a/src/main/java/team/themoment/hellogsmv3/global/security/SecurityConfig.java
+++ b/src/main/java/team/themoment/hellogsmv3/global/security/SecurityConfig.java
@@ -76,7 +76,7 @@ public class SecurityConfig {
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
-        configuration.setAllowedOriginPatterns(authEnv.allowedOrigins());
+        configuration.setAllowedOrigins(authEnv.allowedOrigins());
 
         configuration.setAllowedMethods(Arrays.asList(HttpMethod.GET.name(),
                 HttpMethod.POST.name(),

--- a/src/main/java/team/themoment/hellogsmv3/global/security/SecurityConfig.java
+++ b/src/main/java/team/themoment/hellogsmv3/global/security/SecurityConfig.java
@@ -76,7 +76,7 @@ public class SecurityConfig {
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
-        configuration.setAllowedOrigins(authEnv.allowedOrigins());
+        configuration.setAllowedOriginPatterns(authEnv.allowedOrigins());
 
         configuration.setAllowedMethods(Arrays.asList(HttpMethod.GET.name(),
                 HttpMethod.POST.name(),

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -83,8 +83,7 @@ spring:
     converters:
       preferred-json-mapper: jackson
 auth:
-  allowed-origins:
-      - '*'
+  allowed-origins: ${ALLOWED_ORIGINS:http://localhost:3000}
 schedule:
   oneseoSubmissionStart: ${ONESEO_SUBMISSION_START}
   oneseoSubmissionEnd: ${ONESEO_SUBMISSION_END}


### PR DESCRIPTION
## 개요

로컬 프론트엔드에서 스테이징 백엔드로 요청 시 쿠키가 브라우저에 저장되지 않는 문제를 수정합니다.
CORS에서 `setAllowedOrigins`에 `*`와 `allowCredentials(true)`를 함께 사용하면 Spring이 예외를 던지는 문제와,
`allowed-origins`가 하드코딩되어 환경별로 유연하게 설정할 수 없었던 문제를 함께 해결합니다.

## 본문

로컬 프론트 개발 환경에서 스테이징 백엔드로 테스트할 때 CORS 정책에 의해 요청이 차단되어 쿠키가 전달되지 않는 문제가 있었습니다.

### 변경

- `SecurityConfig.java`: `setAllowedOrigins` → `setAllowedOriginPatterns` 변경
  - `allowCredentials(true)` 상태에서 `*` origin을 허용하려면 `setAllowedOriginPatterns`을 사용해야 합니다
- `application.yml`: `auth.allowed-origins`를 `${ALLOWED_ORIGINS:http://localhost:3000}` 환경변수로 변경
  - 로컬 기본값: `http://localhost:3000`
  - 스테이징/운영: `ALLOWED_ORIGINS` 환경변수 또는 `DEV_WEB_YML` secret에 허용할 origin 명시 필요