### PR TITLE
[global] 워크플로우 취소 시 Discord 알림 추가

### DIFF
--- a/.github/workflows/hellogsm-prod-cd.yml
+++ b/.github/workflows/hellogsm-prod-cd.yml
@@ -6,6 +6,10 @@ on:
       - 'main'
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   CD:
     runs-on: ubuntu-latest
@@ -56,16 +60,26 @@ jobs:
       - name: Code Deploy
         run: aws deploy create-deployment --application-name hellogsm-prod-codedeploy --deployment-config-name CodeDeployDefault.AllAtOnce --deployment-group-name api-prod-hellogsm-kr --s3-location bucket=${{ secrets.BUCKET_NAME }},bundleType=zip,key=prod/$GITHUB_SHA.zip
 
-      - name: CD Success Notification
-        uses: sarisia/actions-status-discord@v1
-        if: success()
-        with:
-          webhook: ${{ secrets.DISCORD_WEBHOOK }}
-          color: 0x4CAF50
+  notify:
+    runs-on: ubuntu-latest
+    needs: [CD]
+    if: always()
 
-      - name: CD Failure Notification
+    steps:
+      - name: Determine Status
+        id: status
+        run: |
+          if [[ "${{ needs.CD.result }}" == "failure" ]]; then
+            echo "color=0xFF4C4C" >> $GITHUB_OUTPUT
+          elif [[ "${{ needs.CD.result }}" == "success" ]]; then
+            echo "color=0x4CAF50" >> $GITHUB_OUTPUT
+          else
+            echo "color=0xFFA500" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Send Discord Notification
         uses: sarisia/actions-status-discord@v1
-        if: failure()
         with:
           webhook: ${{ secrets.DISCORD_WEBHOOK }}
-          color: 0xFF4C4C
+          status: ${{ needs.CD.result }}
+          color: ${{ steps.status.outputs.color }}

--- a/.github/workflows/hellogsm-prod-ci.yml
+++ b/.github/workflows/hellogsm-prod-ci.yml
@@ -9,6 +9,10 @@ on:
       - 'main'
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   CI:
     runs-on: ubuntu-latest
@@ -36,16 +40,26 @@ jobs:
       - name: Build with Gradle
         run: ./gradlew clean build
 
-      - name: CI Success Notification
-        uses: sarisia/actions-status-discord@v1
-        if: success()
-        with:
-          webhook: ${{ secrets.DISCORD_WEBHOOK }}
-          color: 0x4CAF50
+  notify:
+    runs-on: ubuntu-latest
+    needs: [CI]
+    if: always()
 
-      - name: CI Failure Notification
+    steps:
+      - name: Determine Status
+        id: status
+        run: |
+          if [[ "${{ needs.CI.result }}" == "failure" ]]; then
+            echo "color=0xFF4C4C" >> $GITHUB_OUTPUT
+          elif [[ "${{ needs.CI.result }}" == "success" ]]; then
+            echo "color=0x4CAF50" >> $GITHUB_OUTPUT
+          else
+            echo "color=0xFFA500" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Send Discord Notification
         uses: sarisia/actions-status-discord@v1
-        if: failure()
         with:
           webhook: ${{ secrets.DISCORD_WEBHOOK }}
-          color: 0xFF4C4C
+          status: ${{ needs.CI.result }}
+          color: ${{ steps.status.outputs.color }}

--- a/.github/workflows/hellogsm-stage-cd.yml
+++ b/.github/workflows/hellogsm-stage-cd.yml
@@ -6,6 +6,10 @@ on:
       - "develop"
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   CD:
     runs-on: ubuntu-latest
@@ -55,16 +59,26 @@ jobs:
       - name: Code Deploy
         run: aws deploy create-deployment --application-name hellogsm-dev-codedeploy --deployment-config-name CodeDeployDefault.AllAtOnce --deployment-group-name api-stage-hellogsm-kr --s3-location bucket=${{ secrets.BUCKET_NAME }},bundleType=zip,key=dev/$GITHUB_SHA.zip
 
-      - name: CD Success Notification
-        uses: sarisia/actions-status-discord@v1
-        if: success()
-        with:
-          webhook: ${{ secrets.DISCORD_WEBHOOK }}
-          color: 0x4CAF50
+  notify:
+    runs-on: ubuntu-latest
+    needs: [CD]
+    if: always()
 
-      - name: CD Failure Notification
+    steps:
+      - name: Determine Status
+        id: status
+        run: |
+          if [[ "${{ needs.CD.result }}" == "failure" ]]; then
+            echo "color=0xFF4C4C" >> $GITHUB_OUTPUT
+          elif [[ "${{ needs.CD.result }}" == "success" ]]; then
+            echo "color=0x4CAF50" >> $GITHUB_OUTPUT
+          else
+            echo "color=0xFFA500" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Send Discord Notification
         uses: sarisia/actions-status-discord@v1
-        if: failure()
         with:
           webhook: ${{ secrets.DISCORD_WEBHOOK }}
-          color: 0xFF4C4C
+          status: ${{ needs.CD.result }}
+          color: ${{ steps.status.outputs.color }}

--- a/.github/workflows/hellogsm-stage-ci.yml
+++ b/.github/workflows/hellogsm-stage-ci.yml
@@ -9,6 +9,10 @@ on:
       - 'develop'
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   CI:
     runs-on: ubuntu-latest
@@ -36,16 +40,26 @@ jobs:
       - name: Build with Gradle
         run: ./gradlew clean build
 
-      - name: CI Success Notification
-        uses: sarisia/actions-status-discord@v1
-        if: success()
-        with:
-          webhook: ${{ secrets.DISCORD_WEBHOOK }}
-          color: 0x4CAF50
+  notify:
+    runs-on: ubuntu-latest
+    needs: [CI]
+    if: always()
 
-      - name: CI Failure Notification
+    steps:
+      - name: Determine Status
+        id: status
+        run: |
+          if [[ "${{ needs.CI.result }}" == "failure" ]]; then
+            echo "color=0xFF4C4C" >> $GITHUB_OUTPUT
+          elif [[ "${{ needs.CI.result }}" == "success" ]]; then
+            echo "color=0x4CAF50" >> $GITHUB_OUTPUT
+          else
+            echo "color=0xFFA500" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Send Discord Notification
         uses: sarisia/actions-status-discord@v1
-        if: failure()
         with:
           webhook: ${{ secrets.DISCORD_WEBHOOK }}
-          color: 0xFF4C4C
+          status: ${{ needs.CI.result }}
+          color: ${{ steps.status.outputs.color }}


### PR DESCRIPTION
## 개요

워크플로우가 취소(cancelled)될 때 Discord 알림이 전송되지 않는 문제를 해결합니다. 4개의 워크플로우 파일(prod/stage × CI/CD)에 concurrency 설정과 notify 잡을 추가하여 success/failure/cancelled 세 가지 상태 모두 Discord 알림을 전송합니다.

## 본문

기존 워크플로우는 각 잡 내에서 `if: success()`와 `if: failure()` 조건으로만 Discord 알림을 발송하여 취소 시 알림이 누락되었습니다.

### 변경

- `concurrency` 블록 추가: 동일 브랜치에 새 push가 오면 이전 실행을 자동으로 취소
- 기존 CI/CD 잡의 Discord 알림 스텝 제거
- `notify` 잡 분리: `if: always()` 조건으로 성공/실패/취소 모두 실행
  - 성공: 초록(0x4CAF50)
  - 실패: 빨강(0xFF4C4C)
  - 취소: 주황(0xFFA500)

DataGSM 워크플로우 구조를 참고하여 구현했습니다.

---

# RCA 룰

r: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)
c: 웬만하면 반영해 주세요. (Comment)
a: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)