### PR TITLE
[ci/cd] 하네스 동기화 시스템 설정 PR 라벨 자동 부착 비활성화

### DIFF
--- a/.harness/sync.yml
+++ b/.harness/sync.yml
@@ -24,3 +24,4 @@ overrides:
 base_branch: develop
 branch_prefix: harness-sync/
 language: ko
+pr_label: false


### PR DESCRIPTION
## 개요

`harness sync` 동작 설정 파일인 `.harness/sync.yml`에 `pr_label` 옵션을 추가하여, 동기화 PR 생성 시 라벨 자동 부착을 비활성화하였습니다.

## 본문

### 변경

- `.harness/sync.yml`에 `pr_label: false` 설정을 추가하였습니다.
- 해당 옵션을 통해 `harness sync`가 생성하는 PR에 라벨이 자동으로 부착되지 않도록 변경하였습니다.
