### PR TITLE
[global] `gradle-test` 하네스 훅 활성화

### DIFF
--- a/.harness/sync.yml
+++ b/.harness/sync.yml
@@ -14,12 +14,14 @@ overrides:
   claude/hooks/secret-guard: true
   claude/hooks/command-guard: true
   claude/hooks/spotless: true
+  claude/hooks/gradle-test: true
 
   codex/hooks/dispatcher: true
   codex/hooks-json: true
   codex/hooks/secret-guard: true
   codex/hooks/command-guard: true
   codex/hooks/spotless: true
+  codex/hooks/gradle-test: true
 
 base_branch: develop
 branch_prefix: harness-sync/


### PR DESCRIPTION
## 변경 사항

`.harness/sync.yml`에 `gradle-test` 하네스 훅을 활성화합니다.

- `claude/hooks/gradle-test: true`
- `codex/hooks/gradle-test: true`

## 배경

`*ServiceImpl.kt` 저장 시 대응 Gradle 테스트 태스크를 자동 실행하는 훅입니다 (JUnit·Kotest 등 프레임워크 무관). 단일/멀티/중첩 모듈 구조를 모두 처리합니다.

다음 하네스 sync에서 `gradle-test` 훅 디렉터리가 배포됩니다.