### PR TITLE
[global] 로컬 `Origin` 세션 쿠키 도메인 제외

### DIFF
--- a/src/main/java/team/themoment/hellogsmv3/global/security/SessionConfig.java
+++ b/src/main/java/team/themoment/hellogsmv3/global/security/SessionConfig.java
@@ -38,7 +38,7 @@ public class SessionConfig {
     private static final String SUBDOMAIN_COOKIE_PATTERN = "^(?:.+\\.)?(%s)$";
     private static final String ORIGIN_HEADER = "Origin";
     private static final String REFERER_HEADER = "Referer";
-    private static final List<String> LOCAL_HOSTS = List.of("localhost", "127.0.0.1", "::1");
+    private static final List<String> LOCAL_HOSTS = List.of("localhost", "127.0.0.1", "::1", "[::1]");
 
     private final ServerProperties serverProperties;
     private final Environment environment;

--- a/src/main/java/team/themoment/hellogsmv3/global/security/SessionConfig.java
+++ b/src/main/java/team/themoment/hellogsmv3/global/security/SessionConfig.java
@@ -1,6 +1,9 @@
 package team.themoment.hellogsmv3.global.security;
 
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.Arrays;
+import java.util.List;
 import java.util.regex.Pattern;
 
 import org.springframework.boot.web.server.Cookie;
@@ -14,6 +17,7 @@ import org.springframework.session.web.http.DefaultCookieSerializer;
 import org.springframework.util.StringUtils;
 
 import jakarta.annotation.PostConstruct;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 
 /**
@@ -32,6 +36,9 @@ public class SessionConfig {
     private static final String DEFAULT_COOKIE_NAME = "SESSION";
     private static final String DEFAULT_COOKIE_PATH = "/";
     private static final String SUBDOMAIN_COOKIE_PATTERN = "^(?:.+\\.)?(%s)$";
+    private static final String ORIGIN_HEADER = "Origin";
+    private static final String REFERER_HEADER = "Referer";
+    private static final List<String> LOCAL_HOSTS = List.of("localhost", "127.0.0.1", "::1");
 
     private final ServerProperties serverProperties;
     private final Environment environment;
@@ -52,6 +59,12 @@ public class SessionConfig {
     @Bean
     public CookieSerializer cookieSerializer() {
         Cookie cookie = serverProperties.getServlet().getSession().getCookie();
+        DefaultCookieSerializer sharedDomainSerializer = createCookieSerializer(cookie, true);
+        DefaultCookieSerializer hostOnlySerializer = createCookieSerializer(cookie, false);
+        return new LocalOriginCookieSerializer(sharedDomainSerializer, hostOnlySerializer);
+    }
+
+    private DefaultCookieSerializer createCookieSerializer(Cookie cookie, boolean useConfiguredDomain) {
         DefaultCookieSerializer serializer = new DefaultCookieSerializer();
         serializer.setCookieName(StringUtils.hasText(cookie.getName()) ? cookie.getName() : DEFAULT_COOKIE_NAME);
         serializer.setCookiePath(StringUtils.hasText(cookie.getPath()) ? cookie.getPath() : DEFAULT_COOKIE_PATH);
@@ -62,9 +75,43 @@ public class SessionConfig {
         if (cookie.getSecure() != null) {
             serializer.setUseSecureCookie(cookie.getSecure());
         }
-        if (StringUtils.hasText(cookie.getDomain())) {
+        if (useConfiguredDomain && StringUtils.hasText(cookie.getDomain())) {
             serializer.setDomainNamePattern(SUBDOMAIN_COOKIE_PATTERN.formatted(Pattern.quote(cookie.getDomain())));
         }
         return serializer;
+    }
+
+    private record LocalOriginCookieSerializer(DefaultCookieSerializer sharedDomainSerializer,
+            DefaultCookieSerializer hostOnlySerializer) implements CookieSerializer {
+
+        @Override
+        public List<String> readCookieValues(HttpServletRequest request) {
+            return sharedDomainSerializer.readCookieValues(request);
+        }
+
+        @Override
+        public void writeCookieValue(CookieValue cookieValue) {
+            if (hasLocalOrigin(cookieValue.getRequest())) {
+                hostOnlySerializer.writeCookieValue(cookieValue);
+                return;
+            }
+            sharedDomainSerializer.writeCookieValue(cookieValue);
+        }
+
+        private boolean hasLocalOrigin(HttpServletRequest request) {
+            String origin = request.getHeader(ORIGIN_HEADER);
+            if (!StringUtils.hasText(origin)) {
+                origin = request.getHeader(REFERER_HEADER);
+            }
+            if (!StringUtils.hasText(origin)) {
+                return false;
+            }
+            try {
+                String host = new URI(origin).getHost();
+                return host != null && LOCAL_HOSTS.contains(host);
+            } catch (URISyntaxException e) {
+                return false;
+            }
+        }
     }
 }

--- a/src/main/java/team/themoment/hellogsmv3/global/security/SessionConfig.java
+++ b/src/main/java/team/themoment/hellogsmv3/global/security/SessionConfig.java
@@ -107,11 +107,27 @@ public class SessionConfig {
                 return false;
             }
             try {
-                String host = new URI(origin).getHost();
+                String host = new URI(extractOrigin(origin)).getHost();
                 return host != null && LOCAL_HOSTS.contains(host);
             } catch (URISyntaxException e) {
                 return false;
             }
+        }
+
+        private String extractOrigin(String origin) {
+            int authorityStart = origin.indexOf("://");
+            if (authorityStart < 0) {
+                return origin;
+            }
+            authorityStart += 3;
+            int authorityEnd = origin.length();
+            for (char delimiter : new char[]{'/', '?', '#'}) {
+                int delimiterIndex = origin.indexOf(delimiter, authorityStart);
+                if (delimiterIndex >= 0) {
+                    authorityEnd = Math.min(authorityEnd, delimiterIndex);
+                }
+            }
+            return origin.substring(0, authorityEnd);
         }
     }
 }


### PR DESCRIPTION
## 개요

`localhost` 프론트 개발 서버가 `Next.js` rewrite로 stage API를 호출할 때 세션 쿠키의 `Domain`이 잘못 전달되는 문제를 수정하였습니다.
요청의 `Origin` 또는 `Referer`가 로컬 개발 서버인 경우 세션 쿠키를 host-only로 발급하도록 변경하였습니다.

## 본문

기존 수정은 `request.getServerName()` 기준으로 `server.servlet.session.cookie.domain` 적용 여부를 결정하였습니다.
하지만 `Next.js` rewrite를 거치는 로컬 개발 환경에서는 브라우저의 요청 URL은 `localhost:3000`이고, 백엔드가 받는 요청 host는 `stage.hellogsm.kr`가 됩니다.
이 때문에 백엔드는 배포 도메인 요청으로 판단하여 `Domain=stage.hellogsm.kr`를 응답했고, 브라우저는 `localhost` 응답에 대한 잘못된 `Domain`으로 보고 `Set-Cookie`를 차단하였습니다.

이번 변경에서는 `CookieSerializer`를 로컬 `Origin` 인식 wrapper로 감싸서 `Origin` 또는 `Referer`가 `localhost`, `127.0.0.1`, `::1`인 경우 `Domain` 없는 serializer를 사용하도록 하였습니다.
배포 환경의 `www.stage.hellogsm.kr`, `admin.stage.hellogsm.kr` 등에서는 기존처럼 설정된 상위 도메인 공유 쿠키가 유지됩니다.

### 변경

`SessionConfig`에 공유 도메인용 `DefaultCookieSerializer`와 host-only용 `DefaultCookieSerializer`를 분리하였습니다.
로컬 개발 서버에서 들어온 인증 요청은 host-only 쿠키를 내려주도록 `Origin`/`Referer` 기반 분기를 추가하였습니다.
