### PR TITLE
[oneseo] 성적 대체 로직 else-if 체인 및 졸업자 1-2학기 제외 조건 수정

### DIFF
--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/OneseoService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/OneseoService.java
@@ -73,14 +73,18 @@ public class OneseoService {
 
         if (graduationType == GraduationType.GRADUATE && tmpAchievement3_2 == null) {
             tmpAchievement3_2 = tmpAchievement3_1;
-        } else if (tmpAchievement3_1 == null) {
+        }
+        if (tmpAchievement3_1 == null) {
             tmpAchievement3_1 = tmpAchievement3_2;
-        } else if (tmpAchievement2_1 == null) {
+        }
+        if (tmpAchievement2_1 == null) {
             tmpAchievement2_1 = tmpAchievement2_2;
-        } else if (tmpAchievement2_2 == null) {
+        }
+        if (tmpAchievement2_2 == null) {
             tmpAchievement2_2 = tmpAchievement2_1;
-        } else if (graduationType == GraduationType.CANDIDATE && dto.achievement1_2() == null) {
-            if (dto.achievement1_1() == null) {
+        }
+        if (tmpAchievement1_2 == null) {
+            if (tmpAchievement1_1 == null) {
                 tmpAchievement1_2 = tmpAchievement2_2;
             } else {
                 tmpAchievement1_2 = tmpAchievement1_1;

--- a/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/OneseoServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/OneseoServiceTest.java
@@ -322,11 +322,11 @@ class OneseoServiceTest {
             void it_fills_1_2_with_1_1() {
                 MiddleSchoolAchievementCalcDto resultDto = OneseoService
                         .buildCalcDtoWithFillEmpty(middleSchoolAchievementReqDto, graduationType);
-                assertEquals(resultDto.achievement1_2(), middleSchoolAchievementReqDto.achievement1_1());
-                assertEquals(resultDto.achievement2_1(), middleSchoolAchievementReqDto.achievement2_1());
-                assertEquals(resultDto.achievement2_2(), middleSchoolAchievementReqDto.achievement2_2());
-                assertEquals(resultDto.achievement3_1(), middleSchoolAchievementReqDto.achievement3_1());
-                assertEquals(resultDto.achievement3_2(), middleSchoolAchievementReqDto.achievement3_2());
+                assertEquals(middleSchoolAchievementReqDto.achievement1_1(), resultDto.achievement1_2());
+                assertEquals(middleSchoolAchievementReqDto.achievement2_1(), resultDto.achievement2_1());
+                assertEquals(middleSchoolAchievementReqDto.achievement2_2(), resultDto.achievement2_2());
+                assertEquals(middleSchoolAchievementReqDto.achievement3_1(), resultDto.achievement3_1());
+                assertEquals(middleSchoolAchievementReqDto.achievement3_2(), resultDto.achievement3_2());
                 assertNull(resultDto.gedAvgScore());
             }
         }
@@ -348,11 +348,11 @@ class OneseoServiceTest {
             void it_fills_1_2_with_2_2() {
                 MiddleSchoolAchievementCalcDto resultDto = OneseoService
                         .buildCalcDtoWithFillEmpty(middleSchoolAchievementReqDto, graduationType);
-                assertEquals(resultDto.achievement1_2(), middleSchoolAchievementReqDto.achievement2_2());
-                assertEquals(resultDto.achievement2_1(), middleSchoolAchievementReqDto.achievement2_1());
-                assertEquals(resultDto.achievement2_2(), middleSchoolAchievementReqDto.achievement2_2());
-                assertEquals(resultDto.achievement3_1(), middleSchoolAchievementReqDto.achievement3_1());
-                assertEquals(resultDto.achievement3_2(), middleSchoolAchievementReqDto.achievement3_2());
+                assertEquals(middleSchoolAchievementReqDto.achievement2_2(), resultDto.achievement1_2());
+                assertEquals(middleSchoolAchievementReqDto.achievement2_1(), resultDto.achievement2_1());
+                assertEquals(middleSchoolAchievementReqDto.achievement2_2(), resultDto.achievement2_2());
+                assertEquals(middleSchoolAchievementReqDto.achievement3_1(), resultDto.achievement3_1());
+                assertEquals(middleSchoolAchievementReqDto.achievement3_2(), resultDto.achievement3_2());
                 assertNull(resultDto.gedAvgScore());
             }
         }
@@ -500,11 +500,11 @@ class OneseoServiceTest {
             void it_fills_both_semesters_independently() {
                 MiddleSchoolAchievementCalcDto resultDto = OneseoService
                         .buildCalcDtoWithFillEmpty(middleSchoolAchievementReqDto, graduationType);
-                assertEquals(resultDto.achievement2_1(), middleSchoolAchievementReqDto.achievement2_2());
-                assertEquals(resultDto.achievement1_2(), middleSchoolAchievementReqDto.achievement1_1());
-                assertEquals(resultDto.achievement2_2(), middleSchoolAchievementReqDto.achievement2_2());
-                assertEquals(resultDto.achievement3_1(), middleSchoolAchievementReqDto.achievement3_1());
-                assertEquals(resultDto.achievement3_2(), middleSchoolAchievementReqDto.achievement3_2());
+                assertEquals(middleSchoolAchievementReqDto.achievement2_2(), resultDto.achievement2_1());
+                assertEquals(middleSchoolAchievementReqDto.achievement1_1(), resultDto.achievement1_2());
+                assertEquals(middleSchoolAchievementReqDto.achievement2_2(), resultDto.achievement2_2());
+                assertEquals(middleSchoolAchievementReqDto.achievement3_1(), resultDto.achievement3_1());
+                assertEquals(middleSchoolAchievementReqDto.achievement3_2(), resultDto.achievement3_2());
                 assertNull(resultDto.gedAvgScore());
             }
         }

--- a/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/OneseoServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/OneseoServiceTest.java
@@ -306,6 +306,58 @@ class OneseoServiceTest {
         }
 
         @Nested
+        @DisplayName("졸업자(GRADUATE)이고, 1학년 2학기 성적만 null이면")
+        class Context_with_graduate_and_missing_1_2_only {
+            private GraduationType graduationType;
+
+            @BeforeEach
+            void setUp() {
+                middleSchoolAchievementReqDto = createDefaultDtoBuilder().freeSemester("1-2").achievement1_2(null)
+                        .build();
+                graduationType = GraduationType.GRADUATE;
+            }
+
+            @Test
+            @DisplayName("1학년 2학기 성적을 1학년 1학기 성적으로 채운 DTO를 반환한다")
+            void it_fills_1_2_with_1_1() {
+                MiddleSchoolAchievementCalcDto resultDto = OneseoService
+                        .buildCalcDtoWithFillEmpty(middleSchoolAchievementReqDto, graduationType);
+                assertEquals(resultDto.achievement1_2(), middleSchoolAchievementReqDto.achievement1_1());
+                assertEquals(resultDto.achievement2_1(), middleSchoolAchievementReqDto.achievement2_1());
+                assertEquals(resultDto.achievement2_2(), middleSchoolAchievementReqDto.achievement2_2());
+                assertEquals(resultDto.achievement3_1(), middleSchoolAchievementReqDto.achievement3_1());
+                assertEquals(resultDto.achievement3_2(), middleSchoolAchievementReqDto.achievement3_2());
+                assertNull(resultDto.gedAvgScore());
+            }
+        }
+
+        @Nested
+        @DisplayName("졸업자(GRADUATE)이고, 1학년 성적이 모두 null이면")
+        class Context_with_graduate_and_missing_1_1_and_1_2 {
+            private GraduationType graduationType;
+
+            @BeforeEach
+            void setUp() {
+                middleSchoolAchievementReqDto = createDefaultDtoBuilder().freeSemester("1-2").achievement1_1(null)
+                        .achievement1_2(null).build();
+                graduationType = GraduationType.GRADUATE;
+            }
+
+            @Test
+            @DisplayName("1학년 2학기 성적을 2학년 2학기 성적으로 채운 DTO를 반환한다")
+            void it_fills_1_2_with_2_2() {
+                MiddleSchoolAchievementCalcDto resultDto = OneseoService
+                        .buildCalcDtoWithFillEmpty(middleSchoolAchievementReqDto, graduationType);
+                assertEquals(resultDto.achievement1_2(), middleSchoolAchievementReqDto.achievement2_2());
+                assertEquals(resultDto.achievement2_1(), middleSchoolAchievementReqDto.achievement2_1());
+                assertEquals(resultDto.achievement2_2(), middleSchoolAchievementReqDto.achievement2_2());
+                assertEquals(resultDto.achievement3_1(), middleSchoolAchievementReqDto.achievement3_1());
+                assertEquals(resultDto.achievement3_2(), middleSchoolAchievementReqDto.achievement3_2());
+                assertNull(resultDto.gedAvgScore());
+            }
+        }
+
+        @Nested
         @DisplayName("3학년 1학기 성적이 null이면")
         class Context_with_missing_3_1 {
             private GraduationType graduationType;
@@ -424,6 +476,32 @@ class OneseoServiceTest {
                         .buildCalcDtoWithFillEmpty(middleSchoolAchievementReqDto, graduationType);
                 assertEquals(resultDto.achievement1_2(), middleSchoolAchievementReqDto.achievement2_2());
                 assertEquals(resultDto.achievement2_1(), middleSchoolAchievementReqDto.achievement2_1());
+                assertEquals(resultDto.achievement2_2(), middleSchoolAchievementReqDto.achievement2_2());
+                assertEquals(resultDto.achievement3_1(), middleSchoolAchievementReqDto.achievement3_1());
+                assertEquals(resultDto.achievement3_2(), middleSchoolAchievementReqDto.achievement3_2());
+                assertNull(resultDto.gedAvgScore());
+            }
+        }
+
+        @Nested
+        @DisplayName("2학년 1학기와 1학년 2학기 성적이 동시에 null이면")
+        class Context_with_multiple_missing_semesters_at_once {
+            private GraduationType graduationType;
+
+            @BeforeEach
+            void setUp() {
+                middleSchoolAchievementReqDto = createDefaultDtoBuilder().achievement2_1(null).achievement1_2(null)
+                        .build();
+                graduationType = CANDIDATE;
+            }
+
+            @Test
+            @DisplayName("두 학기 성적을 모두 각자의 대체 성적으로 채운 DTO를 반환한다")
+            void it_fills_both_semesters_independently() {
+                MiddleSchoolAchievementCalcDto resultDto = OneseoService
+                        .buildCalcDtoWithFillEmpty(middleSchoolAchievementReqDto, graduationType);
+                assertEquals(resultDto.achievement2_1(), middleSchoolAchievementReqDto.achievement2_2());
+                assertEquals(resultDto.achievement1_2(), middleSchoolAchievementReqDto.achievement1_1());
                 assertEquals(resultDto.achievement2_2(), middleSchoolAchievementReqDto.achievement2_2());
                 assertEquals(resultDto.achievement3_1(), middleSchoolAchievementReqDto.achievement3_1());
                 assertEquals(resultDto.achievement3_2(), middleSchoolAchievementReqDto.achievement3_2());


### PR DESCRIPTION
## 개요

원서 미리보기/임시저장 시 사용하는 `buildCalcDtoWithFillEmpty`의 성적 대체(fallback) 로직을 수정했습니다. 여러 학기가 동시에 비어있을 때 첫 조건만 적용되던 else-if 체인 버그와, 졸업자(GRADUATE)에게는 1학년 2학기 성적 대체가 적용되지 않던 문제를 해결했습니다.

## 본문

go-hellogsm-score-calculator 저장소의 PR #2, #3에서 졸업자의 1학년 2학기 성적이 실제 배점(18점, 6%)에 반영되도록 변경되고, 자유학기제로 인한 결측 시 대체 성적을 채우는 로직도 CANDIDATE 전용에서 GRADUATE까지 확장되었습니다.

하지만 이 저장소의 `OneseoService.buildCalcDtoWithFillEmpty`에 있는 동일한 로직은 갱신되지 않아, 원서 미리보기/임시저장에서 표시되는 achievement1_2 원본 값과 Go 람다가 실제로 계산한 점수가 어긋나는 문제가 있었습니다. 원인은 두 가지였습니다.

1. 성적 대체 조건들이 `else if` 체인으로 묶여 있어, 여러 학기가 동시에 비어있는 경우 앞쪽 조건 하나만 적용되고 나머지는 무시되는 문제
2. achievement1_2 대체 조건이 `graduationType == CANDIDATE`로 제한되어 있어 졸업자에게는 적용되지 않던 문제

### 변경

- 각 학기 조건을 독립된 `if`문으로 분리해 여러 학기가 동시에 결측이어도 모두 개별적으로 대체되도록 수정했습니다.
- achievement1_2 대체 조건에서 CANDIDATE 제한을 제거해 졸업자도 재학생과 동일한 방식(achievement1_1 또는 achievement2_2로 대체)으로 처리하도록 했습니다.
- `OneseoServiceTest`에 졸업자 + 자유학기 1-2 결측 케이스, 여러 학기 동시 결측 케이스(else-if 체인 회귀 테스트)를 추가했습니다.
