### PR TITLE
[oneseo] 자유학기제 P 등급과 개근 출결 표기를 인식하도록 수정

### DIFF
--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/extraction/MiddleSchoolRecordParser.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/extraction/MiddleSchoolRecordParser.java
@@ -74,12 +74,6 @@ public class MiddleSchoolRecordParser {
      * 해서 숫자 안의 공백을 허용합니다.
      *
      * <p>
-     * 자유학기제 학기는 원점수 없이 {@code P}(이수)만 나옵니다. {@code P}를 성취도 문자에 포함하지 않으면 그 줄 전체가
-     * 매치되지 않아 "과목을 찾지 못함" 경고가 붙는데, 실제로는 자유학기제라 원래 등급이 없는 것이므로 잘못된 경고입니다. 그래서
-     * {@code P}도 성취도 문자로 인정하고, {@link #ACHIEVEMENT_SCORE}에는 넣지 않아 점수는 0(미이수 또는
-     * 해당없음)으로 남깁니다.
-     *
-     * <p>
      * group1=학기, group2=과목, group3=성취도
      */
     private static final Pattern SUBJECT_ROW = Pattern.compile(
@@ -93,15 +87,6 @@ public class MiddleSchoolRecordParser {
      */
     private static final Pattern ATTENDANCE_ROW = Pattern.compile("^([123])\\s+(\\d+)((?:\\s+\\d+){12})\\s*$");
 
-    /**
-     * 결석 · 지각 · 조퇴 · 결과가 전부 없는 학년의 출결 행. 예: {@code 1 190 개근}
-     *
-     * <p>
-     * 결석이 전혀 없으면 12칸을 0으로 나열하는 대신 "개근"으로 요약해서 적는 경우가 실제로 확인되어 별도로 다룹니다.
-     *
-     * <p>
-     * group1=학년, group2=수업일수
-     */
     private static final Pattern ATTENDANCE_PERFECT_ROW = Pattern.compile("^([123])\\s+(\\d+)\\s+개근\\s*$");
 
     /** 봉사활동 행. 예: {@code 1 봉사활동 7} */

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/extraction/MiddleSchoolRecordParser.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/extraction/MiddleSchoolRecordParser.java
@@ -74,10 +74,16 @@ public class MiddleSchoolRecordParser {
      * 해서 숫자 안의 공백을 허용합니다.
      *
      * <p>
+     * 자유학기제 학기는 원점수 없이 {@code P}(이수)만 나옵니다. {@code P}를 성취도 문자에 포함하지 않으면 그 줄 전체가
+     * 매치되지 않아 "과목을 찾지 못함" 경고가 붙는데, 실제로는 자유학기제라 원래 등급이 없는 것이므로 잘못된 경고입니다. 그래서
+     * {@code P}도 성취도 문자로 인정하고, {@link #ACHIEVEMENT_SCORE}에는 넣지 않아 점수는 0(미이수 또는
+     * 해당없음)으로 남깁니다.
+     *
+     * <p>
      * group1=학기, group2=과목, group3=성취도
      */
     private static final Pattern SUBJECT_ROW = Pattern.compile(
-            "^([12])\\s+.*(?<![가-힣ㆍ·])([가-힣][가-힣ㆍ·]*)\\s+(?:[\\d.\\s]+/[\\d.\\s]+\\s*(?:\\([^)]*\\))?\\s+)?([A-E])\\s*(?:\\(\\s*\\d+\\s*\\))?\\s*$");
+            "^([12])\\s+.*(?<![가-힣ㆍ·])([가-힣][가-힣ㆍ·]*)\\s+(?:[\\d.\\s]+/[\\d.\\s]+\\s*(?:\\([^)]*\\))?\\s+)?([A-EP])\\s*(?:\\(\\s*\\d+\\s*\\))?\\s*$");
 
     /**
      * 출결 행. {@code 학년 수업일수 결석(질병/미인정/기타) 지각(3) 조퇴(3) 결과(3)} = 학년 + 수업일수 + 숫자 12개
@@ -86,6 +92,17 @@ public class MiddleSchoolRecordParser {
      * group1=학년, group2=수업일수, group3=숫자 12개
      */
     private static final Pattern ATTENDANCE_ROW = Pattern.compile("^([123])\\s+(\\d+)((?:\\s+\\d+){12})\\s*$");
+
+    /**
+     * 결석 · 지각 · 조퇴 · 결과가 전부 없는 학년의 출결 행. 예: {@code 1 190 개근}
+     *
+     * <p>
+     * 결석이 전혀 없으면 12칸을 0으로 나열하는 대신 "개근"으로 요약해서 적는 경우가 실제로 확인되어 별도로 다룹니다.
+     *
+     * <p>
+     * group1=학년, group2=수업일수
+     */
+    private static final Pattern ATTENDANCE_PERFECT_ROW = Pattern.compile("^([123])\\s+(\\d+)\\s+개근\\s*$");
 
     /** 봉사활동 행. 예: {@code 1 봉사활동 7} */
     private static final Pattern VOLUNTEER_ROW = Pattern.compile("^([123])\\s+봉사활동\\s+(\\d+)");
@@ -312,6 +329,16 @@ public class MiddleSchoolRecordParser {
     }
 
     private boolean readAttendance(String line, ParseContext context) {
+        Matcher perfectMatcher = ATTENDANCE_PERFECT_ROW.matcher(line);
+        if (perfectMatcher.find()) {
+            int grade = Integer.parseInt(perfectMatcher.group(1));
+            context.absentDays[grade - 1] = 0;
+            context.attendanceDays[(grade - 1) * 3] = 0;
+            context.attendanceDays[(grade - 1) * 3 + 1] = 0;
+            context.attendanceDays[(grade - 1) * 3 + 2] = 0;
+            return true;
+        }
+
         Matcher matcher = ATTENDANCE_ROW.matcher(line);
         if (!matcher.find()) {
             return false;

--- a/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/extraction/MiddleSchoolRecordParserTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/extraction/MiddleSchoolRecordParserTest.java
@@ -198,8 +198,6 @@ class MiddleSchoolRecordParserTest {
             @Test
             @DisplayName("P 등급 과목을 0점으로 채우고 누락 경고를 붙이지 않는다")
             void it_treats_pass_grade_as_not_missing() {
-                // 순서: 국어, 사회, 도덕, 역사, 수학, 과학, 기술가정, 정보, 영어. P로 표기된 국어 · 수학 · 영어(index
-                // 0, 4, 8)는 값이 0이더라도 실제로 발견됐으므로 MISSING_SUBJECT 경고가 붙지 않아야 한다.
                 assertThat(result.achievement().achievement1_1()).containsExactly(0, 0, 0, 0, 0, 0, 0, 0, 0);
                 assertThat(result.meta().warnings())
                         .noneMatch(warning -> warning.type() == ExtractionWarningType.MISSING_SUBJECT

--- a/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/extraction/MiddleSchoolRecordParserTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/extraction/MiddleSchoolRecordParserTest.java
@@ -171,6 +171,55 @@ class MiddleSchoolRecordParserTest {
         }
 
         @Nested
+        @DisplayName("자유학기제 P 등급과 개근 출결이 섞인 생활기록부가 주어진 경우")
+        class Context_with_pass_grade_and_perfect_attendance {
+
+            private static final String TEXT_WITH_PASS_AND_PERFECT = """
+                    교과학습발달상황
+                    [1학년]
+                    학기 교과 과목 원점수/과목평균(표준편차) 성취도(수강자수) 비고
+                    1 국어 국어 P
+                    1 수학 수학 P
+                    1 영어 영어 P
+                    출결상황
+                    1 190 개근
+                    """;
+
+            private ExtractedAchievementResDto result;
+
+            @BeforeEach
+            void setUp() {
+                result = new MiddleSchoolRecordParser(new SubjectNameNormalizer()).parse(
+                        new ExtractedTextDto(TEXT_WITH_PASS_AND_PERFECT, 1, true, ExtractionSource.TEXT_LAYER, 1.0),
+                        GraduationType.CANDIDATE,
+                        MiddleSchoolRecordParser.FREE_SEMESTER_SYSTEM);
+            }
+
+            @Test
+            @DisplayName("P 등급 과목을 0점으로 채우고 누락 경고를 붙이지 않는다")
+            void it_treats_pass_grade_as_not_missing() {
+                // 순서: 국어, 사회, 도덕, 역사, 수학, 과학, 기술가정, 정보, 영어. P로 표기된 국어 · 수학 · 영어(index
+                // 0, 4, 8)는 값이 0이더라도 실제로 발견됐으므로 MISSING_SUBJECT 경고가 붙지 않아야 한다.
+                assertThat(result.achievement().achievement1_1()).containsExactly(0, 0, 0, 0, 0, 0, 0, 0, 0);
+                assertThat(result.meta().warnings())
+                        .noneMatch(warning -> warning.type() == ExtractionWarningType.MISSING_SUBJECT
+                                && "achievement1_1".equals(warning.field())
+                                && List.of(0, 4, 8).contains(warning.index()));
+            }
+
+            @Test
+            @DisplayName("개근 출결을 전부 0으로 채운다")
+            void it_treats_perfect_attendance_as_zero() {
+                assertThat(result.achievement().absentDays()).containsExactly(0, null, null);
+                assertThat(result.achievement().attendanceDays())
+                        .containsExactly(0, 0, 0, null, null, null, null, null, null);
+                assertThat(result.meta().warnings())
+                        .noneMatch(warning -> warning.type() == ExtractionWarningType.MISSING_ATTENDANCE
+                                && warning.index() != null && warning.index() == 0);
+            }
+        }
+
+        @Nested
         @DisplayName("자유학기제 졸업예정자의 생활기록부가 주어진 경우")
         class Context_with_free_semester_candidate {
 


### PR DESCRIPTION
## 개요

프론트 팀원이 텍스트 레이어 추출 결과로 테스트하다 발견한 파싱 버그를 신고해줬습니다. 신고 내용을 분석해 확인된 두 가지를 고쳤습니다.

## 본문

신고에는 세 가지 증상이 있었습니다.

1. 자유학기제 "P" 등급 과목이 엉뚱한 값(B, C, E 등)으로 채워짐
2. rawText에 분명히 있는 2·3학년 성적이 통째로 유실됨
3. rawText에 있는 출결·봉사활동이 전부 null로 나옴

코드를 다시 짚어보니 1번과 3번은 원인이 명확했습니다.

- `SUBJECT_ROW`가 성취도 문자를 `[A-E]`로만 한정하고 있어서, 자유학기제의 "P"(이수) 행은 애초에 이 정규식에 매치되지 않습니다. 매치가 안 되면 해당 과목은 그냥 "못 찾음"으로 처리돼 `MISSING_SUBJECT` 경고가 붙는데, 실제로는 자유학기제라 원래 등급이 없는 것뿐이라 이 경고 자체가 잘못된 신호입니다.
- `ATTENDANCE_ROW`는 결석·지각·조퇴·결과를 숫자 12개로 나열한 형태만 인식합니다. 결석이 하나도 없는 학년은 숫자 12개 대신 "개근"으로 요약해서 적는 게 실제 생기부 관행인데, 이 표기 자체를 다루지 않고 있었습니다.

2번(2·3학년 유실)은 신고에 있는 예시(`77/62,3`처럼 소수점이 쉼표인 원점수)로 미루어보면 원점수 파싱 구간이 쉼표를 허용하지 않아서일 가능성이 높지만, 신고 본문이 예시를 생략(`...`)한 상태라 실제 원문인지 신고자가 옮기며 바뀐 건지 구분이 안 됩니다. 봉사활동 표도 마찬가지로 실제 표 형태를 봐야 정규식을 어떻게 고칠지 판단할 수 있습니다. 이 두 가지는 원문 rawText를 프론트에 요청해뒀고, 받는 대로 별도로 고치겠습니다.

### 변경

- `SUBJECT_ROW`가 성취도 문자로 `P`도 인정하도록 확장. `ACHIEVEMENT_SCORE`에는 추가하지 않아 점수는 기존과 동일하게 0(미이수 또는 해당없음)으로 남지만, 더 이상 "못 찾음" 경고는 붙지 않음
- `ATTENDANCE_PERFECT_ROW`를 추가해 `학년 수업일수 개근` 형태를 인식하고 해당 학년의 결석·지각·조퇴·결과를 전부 0으로 채움
- 두 케이스를 검증하는 테스트 추가

